### PR TITLE
Auth{n,z} refactor; fix token generation for 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the [example config files](https://github.com/cesanta/docker_auth/tree/maste
 
 Run with increased verbosity:
 ```{r, engine='bash', count_lines}
-docker run ... cesanta/docker_auth --v=2 /config/auth_config.yml
+docker run ... cesanta/docker_auth --v=2 --alsologtostderr /config/auth_config.yml
 ```
 
 ## Contributing

--- a/auth_server/authn/authn.go
+++ b/auth_server/authn/authn.go
@@ -16,18 +16,27 @@
 
 package authn
 
+import "errors"
+
 // Authentication plugin interface.
-// Implementations must be goroutine-safe.
 type Authenticator interface {
-	// Given a user name and a password (plain text), responds with nil on success
-	// or with any other error on failure.
-	Authenticate(user string, password PasswordString) error
+	// Given a user name and a password (plain text), responds with the result or an error.
+	// Error should only be reported if request could not be serviced, not if it should be denied.
+	// A special NoMatch error is returned if the authorizer could not reach a decision,
+	// e.g. none of the rules matched.
+	// Implementations must be goroutine-safe.
+	Authenticate(user string, password PasswordString) (bool, error)
 
 	// Finalize resources in preparation for shutdown.
 	// When this call is made there are guaranteed to be no Authenticate requests in flight
 	// and there will be no more calls made to this instance.
 	Stop()
+
+	// Human-readable name of the authenticator.
+	Name() string
 }
+
+var NoMatch = errors.New("did not match any rule")
 
 //go:generate go-bindata -pkg authn -modtime 1 -mode 420 data/
 

--- a/auth_server/authn/bindata.go
+++ b/auth_server/authn/bindata.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"time"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 )
 
@@ -200,7 +199,7 @@ func RestoreAsset(dir, name string) error {
         if err != nil {
                 return err
         }
-        err = os.MkdirAll(_filePath(dir, path.Dir(name)), os.FileMode(0755))
+        err = os.MkdirAll(_filePath(dir, filepath.Dir(name)), os.FileMode(0755))
         if err != nil {
                 return err
         }
@@ -224,7 +223,7 @@ func RestoreAssets(dir, name string) error {
         }
         // Dir
         for _, child := range children {
-                err = RestoreAssets(dir, path.Join(name, child))
+                err = RestoreAssets(dir, filepath.Join(name, child))
                 if err != nil {
                         return err
                 }

--- a/auth_server/authn/static_auth.go
+++ b/auth_server/authn/static_auth.go
@@ -18,7 +18,6 @@ package authn
 
 import (
 	"encoding/json"
-	"errors"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -45,18 +44,22 @@ func NewStaticUserAuth(users map[string]*Requirements) *staticUsersAuth {
 	return &staticUsersAuth{users: users}
 }
 
-func (sua *staticUsersAuth) Authenticate(user string, password PasswordString) error {
+func (sua *staticUsersAuth) Authenticate(user string, password PasswordString) (bool, error) {
 	reqs := sua.users[user]
 	if reqs == nil {
-		return errors.New("unknown user")
+		return false, NoMatch
 	}
 	if reqs.Password != nil {
 		if bcrypt.CompareHashAndPassword([]byte(*reqs.Password), []byte(password)) != nil {
-			return errors.New("wrong password")
+			return false, nil
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func (sua *staticUsersAuth) Stop() {
+}
+
+func (sua *staticUsersAuth) Name() string {
+	return "static"
 }

--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -1,0 +1,83 @@
+package authz
+
+import (
+	"encoding/json"
+	"path"
+	"regexp"
+
+	"github.com/golang/glog"
+)
+
+type ACL []ACLEntry
+
+type ACLEntry struct {
+	Match   *MatchConditions `yaml:"match"`
+	Actions *[]string        `yaml:"actions,flow"`
+}
+
+type MatchConditions struct {
+	Account *string `yaml:"account,omitempty" json:"account,omitempty"`
+	Type    *string `yaml:"type,omitempty" json:"type,omitempty"`
+	Name    *string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+type aclAuthorizer struct {
+	acl ACL
+}
+
+func NewACLAuthorizer(acl ACL) Authorizer {
+	return &aclAuthorizer{acl: acl}
+}
+
+func (aa *aclAuthorizer) Authorize(ai *AuthRequestInfo) ([]string, error) {
+	for _, e := range aa.acl {
+		matched := e.Matches(ai)
+		if matched {
+			glog.V(2).Infof("%s matched %s", ai, e)
+			if len(*e.Actions) == 1 && (*e.Actions)[0] == "*" {
+				return ai.Actions, nil
+			}
+			return StringSetIntersection(ai.Actions, *e.Actions), nil
+		}
+	}
+	return nil, NoMatch
+}
+
+func (aa *aclAuthorizer) Stop() {
+	// Nothing to do.
+}
+
+func (aa *aclAuthorizer) Name() string {
+	return "static ACL"
+}
+
+type aclEntryJSON *ACLEntry
+
+func (e ACLEntry) String() string {
+	b, _ := json.Marshal(e)
+	return string(b)
+}
+
+func matchString(pp *string, s string) bool {
+	if pp == nil {
+		return true
+	}
+	p := *pp
+	var matched bool
+	var err error
+	if len(p) > 2 && p[0] == '/' && p[len(p)-1] == '/' {
+		matched, err = regexp.Match(p[1:len(p)-1], []byte(s))
+	} else {
+		matched, err = path.Match(p, s)
+	}
+	return err == nil && matched
+}
+
+func (e *ACLEntry) Matches(ai *AuthRequestInfo) bool {
+	if matchString(e.Match.Account, ai.Account) &&
+		matchString(e.Match.Type, ai.Type) &&
+		matchString(e.Match.Name, ai.Name) {
+		return true
+	}
+	return false
+}

--- a/auth_server/authz/authz.go
+++ b/auth_server/authz/authz.go
@@ -1,0 +1,44 @@
+package authz
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Authorizer interface performs authorization of the request.
+// It is invoked after authentication so it can be assumed that the requestor has
+// presented satisfactory credentials for Account.
+// Principally, it answers the question: is this Account allowed to perform these Actions
+// on this Type.Name subject in the give Service?
+type Authorizer interface {
+	// Authorize performs authorization given the request information.
+	// It returns a set of authorized actions (of the set requested), which can be empty/nil.
+	// Error should only be reported if request could not be serviced, not if it should be denied.
+	// A special NoMatch error is returned if the authorizer could not reach a decision,
+	// e.g. none of the rules matched.
+	// Implementations must be goroutine-safe.
+	Authorize(ai *AuthRequestInfo) ([]string, error)
+
+	// Finalize resources in preparation for shutdown.
+	// When this call is made there are guaranteed to be no Authenticate requests in flight
+	// and there will be no more calls made to this instance.
+	Stop()
+
+	// Human-readable name of the authenticator.
+	Name() string
+}
+
+var NoMatch = errors.New("did not match any rule")
+
+type AuthRequestInfo struct {
+	Account string
+	Type    string
+	Name    string
+	Service string
+	Actions []string
+}
+
+func (ai AuthRequestInfo) String() string {
+	return fmt.Sprintf("{%s %s %s %s}", ai.Account, strings.Join(ai.Actions, ","), ai.Type, ai.Name)
+}

--- a/auth_server/authz/set.go
+++ b/auth_server/authz/set.go
@@ -1,0 +1,26 @@
+package authz
+
+import (
+	"sort"
+
+	mapset "github.com/deckarep/golang-set"
+)
+
+func makeSet(ss []string) mapset.Set {
+	set := mapset.NewSet()
+	for _, s := range ss {
+		set.Add(s)
+	}
+	return set
+}
+
+func StringSetIntersection(a, b []string) []string {
+	as := makeSet(a)
+	bs := makeSet(b)
+	d := []string{}
+	for s := range as.Intersect(bs).Iter() {
+		d = append(d, s.(string))
+	}
+	sort.Strings(d)
+	return d
+}

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -31,9 +31,9 @@ token:  # Settings for the tokens.
 users:
   # Password is specified as a BCrypt hash. Use htpasswd -B to generate.
   "admin":
-    password: "$2y$05$SirvKgES6jlgIKDqElQgAu6.3d.czANNYnyPe6SJy4exvAW0cpUjW"
+    password: "$2y$05$LO.vzwpWC5LZGqThvEfznu8qhb5SGqvBSWY1J3yZ4AxtMRZ3kN5jC"  # badmin
   "test":
-    password: "$2y$05$RkZWQNIY8j87k1Wn4MwprOYteXizIRjpTDs6TgeSPlQh045SYybvS"
+    password: "$2y$05$WuwBasGDAgr.QCbGIjKJaep4dhxeai9gNZdmBnQXqpKly57oNutya"  # 123
   "": {}  # Allow anonymous (no "docker login") access.
 
 # Google authentication.

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -19,9 +19,9 @@ token:
 users:
   # Password is specified as a BCrypt hash. Use htpasswd -B to generate.
   "admin":
-    password: "$2y$05$SirvKgES6jlgIKDqElQgAu6.3d.czANNYnyPe6SJy4exvAW0cpUjW"
-  "user":
-    password: "$2y$05$RkZWQNIY8j87k1Wn4MwprOYteXizIRjpTDs6TgeSPlQh045SYybvS"
+    password: "$2y$05$LO.vzwpWC5LZGqThvEfznu8qhb5SGqvBSWY1J3yZ4AxtMRZ3kN5jC"  # badmin
+  "test":
+    password: "$2y$05$WuwBasGDAgr.QCbGIjKJaep4dhxeai9gNZdmBnQXqpKly57oNutya"  # 123
 
 acl:
   # Admin has full access to everything.


### PR DESCRIPTION
Since 1.8 Docker will always request push and pull actions (scopes),
and we should return the subset that is allowed.

Fixes #22
docker/docker#15640

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/23)
<!-- Reviewable:end -->
