### PR TITLE
Add support for variables of authrequestinfo in the ACL of the config file

### DIFF
--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -58,13 +59,19 @@ func (e ACLEntry) String() string {
 	return string(b)
 }
 
-func matchString(pp *string, s string) bool {
+func matchString(pp *string, s string, ai *AuthRequestInfo) bool {
 	if pp == nil {
 		return true
 	}
 	p := *pp
 	var matched bool
 	var err error
+	
+	// replace each known variable
+	r := strings.NewReplacer("${account}",ai.Account,"${type}",ai.Type,"${name}",ai.Name,"${service}",ai.Service)
+	p = r.Replace(p)
+		
+		
 	if len(p) > 2 && p[0] == '/' && p[len(p)-1] == '/' {
 		matched, err = regexp.Match(p[1:len(p)-1], []byte(s))
 	} else {
@@ -74,9 +81,9 @@ func matchString(pp *string, s string) bool {
 }
 
 func (e *ACLEntry) Matches(ai *AuthRequestInfo) bool {
-	if matchString(e.Match.Account, ai.Account) &&
-		matchString(e.Match.Type, ai.Type) &&
-		matchString(e.Match.Name, ai.Name) {
+	if matchString(e.Match.Account, ai.Account, ai) &&
+		matchString(e.Match.Type, ai.Type, ai) &&
+		matchString(e.Match.Name, ai.Name, ai) {
 		return true
 	}
 	return false

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -72,6 +72,12 @@ google_auth:
 #  * Empty actions set means "deny everything", special set consisting of a
 #    single "*" action means "allow everything".
 #  * If no match is found the default is to deny the request.
+#
+# You can use the following variables in any field:
+#  * ${account} - the username of the logged in person
+#  * ${service} - the service to which the user is logging in, e.g. hub.docker.io or my.reg.com:5000
+#  * ${name} - the name of the repository, e.g. centos or john/myrepo
+#  * ${type} - the type of the entity, normally "repository"
 acl:
   # Admin has full access to everything.
   - match: {account: "admin"}
@@ -84,6 +90,9 @@ acl:
   # All logged in users can pull all images.
   - match: {account: "/.+/"}
     actions: ["pull"]
+  # All logged in users can push all images that are in a namespace beginning with their name
+  - match: {account: "/.+/", name: "${account}/*"}
+    actions: ["*"]
   # Anonymous users can pull "hello-world".
   - match: {account: "", name: "hello-world"}
     actions: ["pull"]


### PR DESCRIPTION
Per issue https://github.com/cesanta/docker_auth/issues/20

Added examples in he `reference.yml`. Allows one to say:

````yml
- match: {account: "/.+/", name: "${account}/*"}
    actions: ["*"]
````

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/24)
<!-- Reviewable:end -->
