### PR TITLE
Add support for variables of authrequestinfo in the ACL of the config file

### DIFF
--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/golang/glog"
 )
@@ -58,11 +59,12 @@ func (e ACLEntry) String() string {
 	return string(b)
 }
 
-func matchString(pp *string, s string) bool {
+func matchString(pp *string, s string, vars []string) bool {
 	if pp == nil {
 		return true
 	}
-	p := *pp
+	p := strings.NewReplacer(vars...).Replace(*pp)
+
 	var matched bool
 	var err error
 	if len(p) > 2 && p[0] == '/' && p[len(p)-1] == '/' {
@@ -74,9 +76,15 @@ func matchString(pp *string, s string) bool {
 }
 
 func (e *ACLEntry) Matches(ai *AuthRequestInfo) bool {
-	if matchString(e.Match.Account, ai.Account) &&
-		matchString(e.Match.Type, ai.Type) &&
-		matchString(e.Match.Name, ai.Name) {
+	vars := []string{
+		"${account}", regexp.QuoteMeta(ai.Account),
+		"${type}", regexp.QuoteMeta(ai.Type),
+		"${name}", regexp.QuoteMeta(ai.Name),
+		"${service}", regexp.QuoteMeta(ai.Service),
+	}
+	if matchString(e.Match.Account, ai.Account, vars) &&
+		matchString(e.Match.Type, ai.Type, vars) &&
+		matchString(e.Match.Name, ai.Name, vars) {
 		return true
 	}
 	return false

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -72,6 +72,12 @@ google_auth:
 #  * Empty actions set means "deny everything", special set consisting of a
 #    single "*" action means "allow everything".
 #  * If no match is found the default is to deny the request.
+#
+# You can use the following variables from the ticket request in any field:
+#  * ${account} - the account name, currently the same as authenticated user's name.
+#  * ${service} - the service name, specified by auth.token.service in the registry config.
+#  * ${type} - the type of the entity, normally "repository".
+#  * ${name} - the name of the repository (i.e. image), e.g. centos.
 acl:
   # Admin has full access to everything.
   - match: {account: "admin"}
@@ -84,6 +90,9 @@ acl:
   # All logged in users can pull all images.
   - match: {account: "/.+/"}
     actions: ["pull"]
+  # All logged in users can push all images that are in a namespace beginning with their name
+  - match: {account: "/.+/", name: "${account}/*"}
+    actions: ["*"]
   # Anonymous users can pull "hello-world".
   - match: {account: "", name: "hello-world"}
     actions: ["pull"]


### PR DESCRIPTION
a cleanup of #24

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/26)
<!-- Reviewable:end -->
