### PR TITLE
Disable broken SSLv3 and force strong ciphers to match Docker Registry 2.1 security

### DIFF
--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -54,6 +54,17 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 		}
 		tlsConfig = &tls.Config{
 			MinVersion: tls.VersionTLS10,
+			PreferServerCipherSuites: true,
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
 			NextProtos:   []string{"http/1.1"},
 			Certificates: make([]tls.Certificate, 1),
 		}

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -53,6 +53,7 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 			glog.Exitf("Failed to load certificate and key: both were not provided")
 		}
 		tlsConfig = &tls.Config{
+			MinVersion: tls.VersionTLS10,
 			NextProtos:   []string{"http/1.1"},
 			Certificates: make([]tls.Certificate, 1),
 		}


### PR DESCRIPTION
SSLv3 is broken but is still enabled in crypto/tls.  Docker Registry 2.1 has already implemented a workaround, so we should follow their lead here.  See https://github.com/docker/distribution/commit/dc5869de0b4fcab4f0291c8e835560951c5e968a

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/28)
<!-- Reviewable:end -->
