### PR TITLE
Trim space from LDAP password before use

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -92,8 +92,9 @@ func (la *LDAPAuth) bindReadOnlyUser(l *ldap.Conn) error {
 		if err != nil {
 			return err
 		}
-		glog.V(2).Infof("Bind read-only user %s", string(password))
-		err = l.Bind(la.config.BindDN, string(password))
+		password_str := strings.TrimSpace(string(password))
+		glog.V(2).Infof("Bind read-only user %s", password_str)
+		err = l.Bind(la.config.BindDN, password_str)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Makes it editor-friendly.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/34)
<!-- Reviewable:end -->
