### PR TITLE
enable ldap tls connection

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -126,6 +126,7 @@ func (as *AuthServer) Authenticate(ar *AuthRequest) (bool, error) {
 func (as *AuthServer) Authorize(ar *AuthRequest) ([]string, error) {
 	for i, a := range as.authorizers {
 		result, err := a.Authorize(&ar.ai)
+
 		glog.V(2).Infof("Authz %s %s -> %s, %s", a.Name(), ar.ai, result, err)
 		if err != nil {
 			if err == authz.NoMatch {

--- a/examples/ldap_auth.yml
+++ b/examples/ldap_auth.yml
@@ -6,8 +6,12 @@ token:
   issuer: Acme auth server
   expiration: 900
 ldap_auth:
-  addr: ldap.example.com:389
-  tls: true
+  addr: ldap.example.com:636
+  # Setup connection method to be
+  # plain: the communication won't be encrypted, if method is not set, default is plain
+  # simple_tls
+  # starttls
+  method: simple_tls
   bind_dn:
   bind_password_file:
   base: o=example.com

--- a/examples/ldap_auth.yml
+++ b/examples/ldap_auth.yml
@@ -1,19 +1,19 @@
 server:
   addr: :5001
-  certificate: /path/to/server.pem 
+  certificate: /path/to/server.pem
   key: /path/to/server.key
 token:
   issuer: Acme auth server
   expiration: 900
 ldap_auth:
   addr: ldap.example.com:636
-  # Setup connection method to be
-  # plain: the communication won't be encrypted, if method is not set, default is plain
-  # simple_tls
-  # starttls
-  method: simple_tls
-  bind_dn:
-  bind_password_file:
+  # Setup tls connection method to be
+  # "" or "none": the communication won't be encrypted
+  # always: setup LDAP over SSL/TLS
+  # starttls: sets StartTLS as the encryption method
+  tls: always 
+  bind_dn: 
+  bind_password_file: 
   base: o=example.com
   filter: (&(uid=${account})(objectClass=person))
 acl:


### PR DESCRIPTION
Fix for issue #37 to enable SSL/TLS connection to LDAP server. Now "plain", "simple_tls", "starttls" is supported. Usually "plain" and "starttls" goes from port 389, and "simple_tls" uses 636.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/40)
<!-- Reviewable:end -->
