### PR TITLE
Add comment field to ACLs

### DIFF
--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -14,6 +14,7 @@ type ACL []ACLEntry
 type ACLEntry struct {
 	Match   *MatchConditions `yaml:"match"`
 	Actions *[]string        `yaml:"actions,flow"`
+	Comment *string          `yaml:"comment,omitempty"`
 }
 
 type MatchConditions struct {
@@ -34,7 +35,7 @@ func (aa *aclAuthorizer) Authorize(ai *AuthRequestInfo) ([]string, error) {
 	for _, e := range aa.acl {
 		matched := e.Matches(ai)
 		if matched {
-			glog.V(2).Infof("%s matched %s", ai, e)
+			glog.V(2).Infof("%s matched %s (Comment: %s)", ai, e, e.Comment)
 			if len(*e.Actions) == 1 && (*e.Actions)[0] == "*" {
 				return ai.Actions, nil
 			}

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -96,21 +96,22 @@ ldap_auth:
 #  * ${type} - the type of the entity, normally "repository".
 #  * ${name} - the name of the repository (i.e. image), e.g. centos.
 acl:
-  # Admin has full access to everything.
   - match: {account: "admin"}
     actions: ["*"]
-  # User "test" has full access to test-* images but nothing else.
+    comment: "Admin has full access to everything."
   - match: {account: "test", name: "test-*"}
     actions: ["*"]
+    comment: "User \"test\" has full access to test-* images but nothing else. (1)"
   - match: {account: "test"}
     actions: []
-  # All logged in users can pull all images.
+    comment: "User \"test\" has full access to test-* images but nothing else. (2)"
   - match: {account: "/.+/"}
     actions: ["pull"]
-  # All logged in users can push all images that are in a namespace beginning with their name
+    comment: "All logged in users can pull all images."
   - match: {account: "/.+/", name: "${account}/*"}
     actions: ["*"]
-  # Anonymous users can pull "hello-world".
+    comment: "All logged in users can push all images that are in a namespace beginning with their name"
   - match: {account: "", name: "hello-world"}
     actions: ["pull"]
+    comment: "Anonymous users can pull \"hello-world\"."
   # Access is denied by default.

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -24,10 +24,10 @@ users:
     password: "$2y$05$WuwBasGDAgr.QCbGIjKJaep4dhxeai9gNZdmBnQXqpKly57oNutya"  # 123
 
 acl:
-  # Admin has full access to everything.
   - match: {account: "admin"}
     actions: ["*"]
-  # User "user" can pull stuff.
+    comment: "Admin has full access to everything."
   - match: {account: "user"}
     actions: ["pull"]
+    comment: "User \"user\" can pull stuff."
   # Access is denied by default.


### PR DESCRIPTION
When ACLs are stored outside of the static YAML configuration file one
might be interested in a context about the ACL.

I proposed a database (e.g. MongoDB) ACL backend in #38 and that's why I
need the comment field on an ACL.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/42)
<!-- Reviewable:end -->
