### PR TITLE
Make image name configurable, use golang-builder, compress bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Supported authorization methods:
 A public Docker image is available on Docker Hub: [cesanta/docker_auth:stable](https://registry.hub.docker.com/u/cesanta/docker_auth/).
 
 The binary takes a single argument - path to the config file.
+If no arguments are given, the Dockerfile defaults to `/config/auth_config.yml`.
 
 Example command line:
 

--- a/auth_server/.gitignore
+++ b/auth_server/.gitignore
@@ -1,1 +1,2 @@
 auth_server
+Godeps/

--- a/auth_server/Dockerfile
+++ b/auth_server/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.5
+FROM busybox
 EXPOSE 5001
-ADD auth_server /
 ENTRYPOINT ["/auth_server"]
+CMD ["/config/auth_config.yml"]
+COPY auth_server .

--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -1,20 +1,34 @@
-.PHONY: update-deps build docker-build
+MAKEFLAGS += --warn-undefined-variables
+IMAGE ?= cesanta/docker_auth
+COMPRESS_BINARY ?= false
+
+BUILDER_IMAGE ?= centurylink/golang-builder
+BUILDER_IMAGE_EXTRA-build-cross = -cross
+BUILDER_OPTS-docker-build = -v /var/run/docker.sock:/var/run/docker.sock
+
+.PHONY: %
 
 all: build
+local: build-local
 
 update-deps:
-	go get -v -u -f github.com/jteeuwen/go-bindata/... .
+	go get -v -u -f github.com/tools/godep github.com/jteeuwen/go-bindata/... .
 
-build:
+godep:
+	godep save
+
+build-local: update-deps
 	go generate ./...
 	go build
 
-docker-build: update-deps build
-	docker build -t cesanta/docker_auth -f Dockerfile .
+build build-cross docker-build: update-deps godep
+	docker run --rm -v $(PWD):/src -e COMPRESS_BINARY=$(COMPRESS_BINARY) $(BUILDER_OPTS-$@) $(BUILDER_IMAGE)$(BUILDER_IMAGE_EXTRA-$@) $(IMAGE)
 
-docker-push-latest:
-	docker push cesanta/docker_auth:latest
+docker-tag-%:
+	docker tag -f $(IMAGE):latest $(IMAGE):$*
 
-docker-push-stable:
-	docker tag -f cesanta/docker_auth:latest cesanta/docker_auth:stable
-	docker push cesanta/docker_auth:stable
+docker-push-%: docker-tag-%
+	docker push $(IMAGE):$*
+
+# Shortcut for latest
+docker-push: docker-push-latest

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package main
+package main // import "github.com/cesanta/docker_auth/auth_server"
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
This switches this to use golang-builder to make it a bit easier for switching between OSX and Linux.

I also added some commands to the Makefile to make some things more configurable, made /config/config.yml the default location to look for configs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/46)
<!-- Reviewable:end -->
