### PR TITLE
move docker-build outside of normal build target

### DIFF
--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -26,8 +26,10 @@ build-local: update-deps
 ca-certificates.crt:
 	cp $(CA_BUNDLE) .
 
-build build-cross docker-build: update-deps godep ca-certificates.crt
+docker-build:
 	docker run --rm -v $(PWD):/src -e COMPRESS_BINARY=$(COMPRESS_BINARY) $(BUILDER_OPTS-$@) $(BUILDER_IMAGE)$(BUILDER_IMAGE_EXTRA-$@) $(IMAGE)
+
+build build-cross: update-deps godep ca-certificates.crt docker-build
 
 docker-tag-%:
 	docker tag -f $(IMAGE):latest $(IMAGE):$*


### PR DESCRIPTION
This makes it much easier to rebuild the project by itself if you don't need updated deps or the full image

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/54)
<!-- Reviewable:end -->
