### PR TITLE
Make ACLMongo omitempty for serialization

### DIFF
--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	LDAPAuth   *authn.LDAPAuthConfig          `yaml:"ldap_auth,omitempty"`
 	MongoAuth  *authn.MongoAuthConfig         `yaml:"mongo_auth,omitempty"`
 	ACL        authz.ACL                      `yaml:"acl"`
-	ACLMongo   *authz.ACLMongoConfig          `yaml:"acl_mongo"`
+	ACLMongo   *authz.ACLMongoConfig          `yaml:"acl_mongo,omitempty"`
 }
 
 type ServerConfig struct {


### PR DESCRIPTION
Hello,

I updated the config struct to ommit ACLMongo if empty, to avoid having `ACLMongo:  null` on serialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/70)
<!-- Reviewable:end -->
