### PR TITLE
Handle "invalid credentials" as a non-error

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -75,10 +75,16 @@ func (la *LDAPAuth) Authenticate(account string, password PasswordString) (bool,
 	if uSearchErr != nil {
 		return false, uSearchErr
 	}
+	if accountEntryDN == "" {
+		return false, nil // User does not exist
+	}
 	// Bind as the user to verify their password
 	if len(accountEntryDN) > 0 {
 		err := l.Bind(accountEntryDN, string(password))
 		if err != nil {
+			if ldap.IsErrorWithCode(err, ldap.LDAPResultInvalidCredentials) {
+				return false, nil
+			}
 			return false, err
 		}
 	}
@@ -173,8 +179,10 @@ func (la *LDAPAuth) ldapSearch(l *ldap.Conn, baseDN *string, filter *string, att
 		return "", err
 	}
 
-	if len(sr.Entries) != 1 {
-		return "", fmt.Errorf("User does not exist or too many entries returned.")
+	if len(sr.Entries) == 0 {
+		return "", nil // User does not exist
+	} else if len(sr.Entries) > 1 {
+		return "", fmt.Errorf("Too many entries returned.")
 	}
 
 	var buffer bytes.Buffer


### PR DESCRIPTION
It's kind of expected, we should return 403 in this case and not 500.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/104)
<!-- Reviewable:end -->
