### PR TITLE
Return NoMatch when user does not exist in LDAP

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -76,7 +76,7 @@ func (la *LDAPAuth) Authenticate(account string, password PasswordString) (bool,
 		return false, uSearchErr
 	}
 	if accountEntryDN == "" {
-		return false, nil // User does not exist
+		return false, NoMatch // User does not exist
 	}
 	// Bind as the user to verify their password
 	if len(accountEntryDN) > 0 {


### PR DESCRIPTION
The LDAP authn provider currently returns no error when the user is not found in LDAP.

For this reason, it fails authentication without checking the next authenticator, which is a wrong behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/114)
<!-- Reviewable:end -->
