### PR TITLE
Add positional argument for real ip header.

### DIFF
--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -47,6 +47,7 @@ type Config struct {
 type ServerConfig struct {
 	ListenAddress string `yaml:"addr,omitempty"`
 	RealIPHeader  string `yaml:"real_ip_header,omitempty"`
+	RealIPPos     int    `yaml:"real_ip_pos,omitempty"`
 	CertFile      string `yaml:"certificate,omitempty"`
 	KeyFile       string `yaml:"key,omitempty"`
 

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -141,7 +141,17 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 	ar := &authRequest{RemoteConnAddr: req.RemoteAddr, RemoteAddr: req.RemoteAddr}
 	if as.config.Server.RealIPHeader != "" {
 		hv := req.Header.Get(as.config.Server.RealIPHeader)
-		ar.RemoteAddr = strings.TrimSpace(strings.Split(hv, ",")[0])
+		ips := strings.Split(hv, ",")
+
+		realIPPos := as.config.Server.RealIPPos
+		if realIPPos < 0 {
+			realIPPos = len(ips) + realIPPos
+			if realIPPos < 0 {
+				realIPPos = 0
+			}
+		}
+
+		ar.RemoteAddr = strings.TrimSpace(ips[realIPPos])
 		glog.V(3).Infof("Conn ip %s, %s: %s, addr: %s", ar.RemoteAddr, as.config.Server.RealIPHeader, hv, ar.RemoteAddr)
 		if ar.RemoteAddr == "" {
 			return nil, fmt.Errorf("client address not provided")

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -20,6 +20,9 @@ server:  # Server settings.
   # May be useful if the server is behind a proxy or load balancer.
   # If configured, this header must be present, requests without it will be rejected.
   # real_ip_header: "X-Forwarded-For"
+  # Optional position of client ip in X-Forwarded-For, negative starts from
+  # end of addresses.
+  # real_ip_pos: -2
 
 token:  # Settings for the tokens.
   issuer: "Acme auth server"  # Must match issuer in the Registry config.


### PR DESCRIPTION
Going to submit a few PRs for stuff we've found useful.

Currently the real IP header functionality defaults to grabbing the first IP address.  This would put responsibility of protecting the header upstream.  By adding a position argument I can easily select the trusted position of the header.

For example, we have this behind a google load balancer which provides the client IP for us in `X-Forwarded-For`: https://cloud.google.com/compute/docs/load-balancing/http/

The load balancer provides a header in the format of: `X-Forwarded-For: <client IP(s)>, <global forwarding rule external IP>`

Something like `X-Forwarded-For: 104.196.118.51, 130.211.9.23` is received where `104.196.118.51` is the client IP, `130.211.9.23` is the load balancer IP.

Now let's say that I attempt to spoof the header via curl:

```
curl -H "X-Forwarded-For: 10.0.0.1" https://registry
```

then the header turns into `X-Forwarded-For: 10.0.0.1, 104.196.118.51, 130.211.9.23`.  By default, reg-auth would just the provided IP in curl.

By defining a position that takes negative values (in this case -2), we were easily able to select the trusted IP regardless of what the client provided without needing more complexity upstream.

That's a lot, hope it makes sense.  More to come.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/137)
<!-- Reviewable:end -->
