### PR TITLE
Auth labels

### DIFF
--- a/auth_server/authn/authn.go
+++ b/auth_server/authn/authn.go
@@ -18,6 +18,8 @@ package authn
 
 import "errors"
 
+type Labels map[string][]string
+
 // Authentication plugin interface.
 type Authenticator interface {
 	// Given a user name and a password (plain text), responds with the result or an error.
@@ -26,7 +28,7 @@ type Authenticator interface {
 	// e.g. none of the rules matched.
 	// Another special WrongPass error is returned if the authorizer failed to authenticate.
 	// Implementations must be goroutine-safe.
-	Authenticate(user string, password PasswordString) (bool, error)
+	Authenticate(user string, password PasswordString) (bool, Labels, error)
 
 	// Finalize resources in preparation for shutdown.
 	// When this call is made there are guaranteed to be no Authenticate requests in flight

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -235,17 +235,17 @@ func (gha *GitHubAuth) validateServerToken(user string) (*TokenDBValue, error) {
 	return v, nil
 }
 
-func (gha *GitHubAuth) Authenticate(user string, password PasswordString) (bool, error) {
+func (gha *GitHubAuth) Authenticate(user string, password PasswordString) (bool, Labels, error) {
 	err := gha.db.ValidateToken(user, password)
 	if err == ExpiredToken {
 		_, err = gha.validateServerToken(user)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
 	} else if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return true, nil
+	return true, nil, nil
 }
 
 func (gha *GitHubAuth) Stop() {

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -399,17 +399,17 @@ func (ga *GoogleAuth) doGoogleAuthSignOut(rw http.ResponseWriter, token string) 
 	fmt.Fprint(rw, "signed out")
 }
 
-func (ga *GoogleAuth) Authenticate(user string, password PasswordString) (bool, error) {
+func (ga *GoogleAuth) Authenticate(user string, password PasswordString) (bool, Labels, error) {
 	err := ga.db.ValidateToken(user, password)
 	if err == ExpiredToken {
 		_, err = ga.validateServerToken(user)
 		if err != nil {
-			return false, err
+			return false, nil, err
 		}
 	} else if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return true, nil
+	return true, nil, nil
 }
 
 func (ga *GoogleAuth) Stop() {

--- a/auth_server/authn/mongo_auth.go
+++ b/auth_server/authn/mongo_auth.go
@@ -82,7 +82,7 @@ func NewMongoAuth(c *MongoAuthConfig) (*MongoAuth, error) {
 	}, nil
 }
 
-func (mauth *MongoAuth) Authenticate(account string, password PasswordString) (bool, error) {
+func (mauth *MongoAuth) Authenticate(account string, password PasswordString) (bool, Labels, error) {
 	for true {
 		result, err := mauth.authenticate(account, password)
 		if err == io.EOF {
@@ -90,10 +90,10 @@ func (mauth *MongoAuth) Authenticate(account string, password PasswordString) (b
 			time.Sleep(time.Second)
 			continue
 		}
-		return result, err
+		return result, nil, err
 	}
 
-	return false, errors.New("Unable to communicate with Mongo.")
+	return false, nil, errors.New("Unable to communicate with Mongo.")
 }
 
 func (mauth *MongoAuth) authenticate(account string, password PasswordString) (bool, error) {

--- a/auth_server/authn/static_auth.go
+++ b/auth_server/authn/static_auth.go
@@ -44,17 +44,17 @@ func NewStaticUserAuth(users map[string]*Requirements) *staticUsersAuth {
 	return &staticUsersAuth{users: users}
 }
 
-func (sua *staticUsersAuth) Authenticate(user string, password PasswordString) (bool, error) {
+func (sua *staticUsersAuth) Authenticate(user string, password PasswordString) (bool, Labels, error) {
 	reqs := sua.users[user]
 	if reqs == nil {
-		return false, NoMatch
+		return false, nil, NoMatch
 	}
 	if reqs.Password != nil {
 		if bcrypt.CompareHashAndPassword([]byte(*reqs.Password), []byte(password)) != nil {
-			return false, nil
+			return false, nil, nil
 		}
 	}
-	return true, nil
+	return true, nil, nil
 }
 
 func (sua *staticUsersAuth) Stop() {

--- a/auth_server/authz/authz.go
+++ b/auth_server/authz/authz.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"strings"
+
+	"github.com/cesanta/docker_auth/auth_server/authn"
 )
 
 // Authorizer interface performs authorization of the request.
@@ -39,6 +41,7 @@ type AuthRequestInfo struct {
 	Service string
 	IP      net.IP
 	Actions []string
+	Labels  authn.Labels
 }
 
 func (ai AuthRequestInfo) String() string {

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -143,13 +143,13 @@ func (rs *RestartableServer) WatchConfig() {
 }
 
 func (rs *RestartableServer) MaybeRestart() {
-	glog.Infof("Restarting server")
+	glog.Infof("Validating new config")
 	c, err := server.LoadConfig(rs.configFile)
 	if err != nil {
 		glog.Errorf("Failed to reload config (server not restarted): %s", err)
 		return
 	}
-	glog.Infof("New config loaded")
+	glog.Infof("Config ok, restarting server")
 	rs.hs.Stop()
 	rs.authServer.Stop()
 	rs.authServer, rs.hs = ServeOnce(c, rs.configFile, rs.hd)

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -124,6 +124,10 @@ func validate(c *Config) error {
 	}
 	if c.ACL == nil && c.ACLMongo == nil {
 		return errors.New("ACL is empty, this is probably a mistake. Use an empty list if you really want to deny all actions")
+	} else {
+		if err := authz.ValidateACL(c.ACL); err != nil {
+			return fmt.Errorf("invalid ACL: %s", err)
+		}
 	}
 	if c.ACLMongo != nil {
 		if err := c.ACLMongo.Validate("acl_mongo"); err != nil {

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -108,6 +108,7 @@ type authRequest struct {
 	Account        string
 	Service        string
 	Scopes         []authScope
+	Labels         authn.Labels
 }
 
 type authScope struct {
@@ -192,26 +193,26 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 	return ar, nil
 }
 
-func (as *AuthServer) Authenticate(ar *authRequest) (bool, error) {
+func (as *AuthServer) Authenticate(ar *authRequest) (bool, authn.Labels, error) {
 	for i, a := range as.authenticators {
-		result, err := a.Authenticate(ar.Account, ar.Password)
-		glog.V(2).Infof("Authn %s %s -> %t, %v", a.Name(), ar.Account, result, err)
+		result, labels, err := a.Authenticate(ar.Account, ar.Password)
+		glog.V(2).Infof("Authn %s %s -> %t, %+v, %v", a.Name(), ar.Account, result, labels, err)
 		if err != nil {
 			if err == authn.NoMatch {
 				continue
 			} else if err == authn.WrongPass {
 				glog.Warningf("Failed authentication with %s: %s", err)
-				return false, nil
+				return false, nil, nil
 			}
 			err = fmt.Errorf("authn #%d returned error: %s", i+1, err)
 			glog.Errorf("%s: %s", ar, err)
-			return false, err
+			return false, nil, err
 		}
-		return result, nil
+		return result, labels, nil
 	}
 	// Deny by default.
 	glog.Warningf("%s did not match any authn rule", ar)
-	return false, nil
+	return false, nil, nil
 }
 
 func (as *AuthServer) authorizeScope(ai *authz.AuthRequestInfo) ([]string, error) {
@@ -243,6 +244,7 @@ func (as *AuthServer) Authorize(ar *authRequest) ([]authzResult, error) {
 			Service: ar.Service,
 			IP:      ar.RemoteIP,
 			Actions: scope.Actions,
+			Labels:  ar.Labels,
 		}
 		actions, err := as.authorizeScope(ai)
 		if err != nil {
@@ -306,7 +308,7 @@ func (as *AuthServer) CreateToken(ar *authRequest, ares []authzResult) (string, 
 	if err != nil || sigAlg2 != sigAlg {
 		return "", fmt.Errorf("failed to sign token: %s", err)
 	}
-	glog.Infof("New token for %s: %s", *ar, claimsJSON)
+	glog.Infof("New token for %s %+v: %s", *ar, ar.Labels, claimsJSON)
 	return fmt.Sprintf("%s%s%s", payload, token.TokenSeparator, joseBase64UrlEncode(sig)), nil
 }
 
@@ -349,7 +351,7 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 	}
 	glog.V(2).Infof("Auth request: %+v", ar)
 	{
-		authnResult, err := as.Authenticate(ar)
+		authnResult, labels, err := as.Authenticate(ar)
 		if err != nil {
 			http.Error(rw, fmt.Sprintf("Authentication failed (%s)", err), http.StatusInternalServerError)
 			return
@@ -359,6 +361,7 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 			http.Error(rw, "Auth failed.", http.StatusUnauthorized)
 			return
 		}
+		ar.Labels = labels
 	}
 	if len(ar.Scopes) > 0 {
 		ares, err = as.Authorize(ar)


### PR DESCRIPTION
Add labels that can be passed from authentication to authorization rules.
Add ability to match them:
```
  acl:
   - match: {labels: {"foo": "bar", "baz": "/quux.*/"}}
```
All the label expressions must match ("and" logic on label expressions).
Labels are a string -> []string map, so a label can have multiple values
and all of them will be tried during matching, but only one is required
("or" logic on label values).

For now, only external authenticator can add labels, but in the future
e.g. GitHub authn can pass down GH organizations or teams the user
belongs to (should help #117).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/139)
<!-- Reviewable:end -->
