### PR TITLE
Support for external authorization

### DIFF
--- a/auth_server/authz/acl_ext.go
+++ b/auth_server/authz/acl_ext.go
@@ -1,0 +1,99 @@
+/*
+   Copyright 2016 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package authz
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+type ACLExtConfig struct {
+	Command string   `yaml:"command"`
+	Args    []string `yaml:"args"`
+}
+
+type ACLExtStatus int
+
+const (
+	ACLExtAllowed ACLExtStatus = 0
+	ACLExtDenied  ACLExtStatus = 1
+	ACLExtError   ACLExtStatus = 2
+)
+
+func (c *ACLExtConfig) Validate() error {
+	if c.Command == "" {
+		return fmt.Errorf("command is not set")
+	}
+	if _, err := exec.LookPath(c.Command); err != nil {
+		return fmt.Errorf("invalid command %q: %s", c.Command, err)
+	}
+	return nil
+}
+
+type ACLExt struct {
+	cfg *ACLExtConfig
+}
+
+func NewACLExtAuthorizer(cfg *ACLExtConfig) *ACLExt {
+	glog.Infof("External authorization: %s %s", cfg.Command, strings.Join(cfg.Args, " "))
+	return &ACLExt{cfg: cfg}
+}
+
+func (ea *ACLExt) Authorize(ai *AuthRequestInfo) ([]string, error) {
+	aiMarshal, err := json.Marshal(ai)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to json.Marshal AuthRequestInfo: %s", err)
+	}
+
+	cmd := exec.Command(ea.cfg.Command, ea.cfg.Args...)
+	cmd.Stdin = strings.NewReader(fmt.Sprintf("%s", aiMarshal))
+	output, err := cmd.Output()
+
+	es := 0
+	et := ""
+	if err == nil {
+	} else if ee, ok := err.(*exec.ExitError); ok {
+		es = ee.Sys().(syscall.WaitStatus).ExitStatus()
+		et = string(ee.Stderr)
+	} else {
+		es = int(ACLExtError)
+		et = fmt.Sprintf("cmd run error: %s", err)
+	}
+	glog.V(2).Infof("%s %s -> %d %s", cmd.Path, cmd.Args, es, output)
+
+	switch ACLExtStatus(es) {
+	case ACLExtAllowed:
+		return ai.Actions, nil
+	case ACLExtDenied:
+		return []string{}, nil
+	default:
+		glog.Errorf("Ext command error: %d %s", es, et)
+	}
+	return nil, fmt.Errorf("bad return code from command: %d", es)
+}
+
+func (sua *ACLExt) Stop() {
+}
+
+func (sua *ACLExt) Name() string {
+	return "external ACL"
+}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	ExtAuth    *authn.ExtAuthConfig           `yaml:"ext_auth,omitempty"`
 	ACL        authz.ACL                      `yaml:"acl,omitempty"`
 	ACLMongo   *authz.ACLMongoConfig          `yaml:"acl_mongo,omitempty"`
-	ACLExt     *authz.ACLExtConfig            `yaml:"acl_ext,omitempty"`
+	ExtAuthz   *authz.ExtAuthzConfig          `yaml:"ext_authz,omitempty"`
 }
 
 type ServerConfig struct {
@@ -124,7 +124,7 @@ func validate(c *Config) error {
 			return fmt.Errorf("bad ext_auth config: %s", err)
 		}
 	}
-	if c.ACL == nil && c.ACLMongo == nil && c.ACLExt == nil {
+	if c.ACL == nil && c.ACLMongo == nil && c.ExtAuthz == nil {
 		return errors.New("ACL is empty, this is probably a mistake. Use an empty list if you really want to deny all actions")
 	}
 
@@ -138,8 +138,8 @@ func validate(c *Config) error {
 			return err
 		}
 	}
-	if c.ACLExt != nil {
-		if err := c.ACLExt.Validate(); err != nil {
+	if c.ExtAuthz != nil {
+		if err := c.ExtAuthz.Validate(); err != nil {
 			return err
 		}
 	}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	ExtAuth    *authn.ExtAuthConfig           `yaml:"ext_auth,omitempty"`
 	ACL        authz.ACL                      `yaml:"acl,omitempty"`
 	ACLMongo   *authz.ACLMongoConfig          `yaml:"acl_mongo,omitempty"`
+	ACLExt     *authz.ACLExtConfig            `yaml:"acl_ext,omitempty"`
 }
 
 type ServerConfig struct {
@@ -123,15 +124,22 @@ func validate(c *Config) error {
 			return fmt.Errorf("bad ext_auth config: %s", err)
 		}
 	}
-	if c.ACL == nil && c.ACLMongo == nil {
+	if c.ACL == nil && c.ACLMongo == nil && c.ACLExt == nil {
 		return errors.New("ACL is empty, this is probably a mistake. Use an empty list if you really want to deny all actions")
-	} else {
+	}
+
+	if c.ACL != nil {
 		if err := authz.ValidateACL(c.ACL); err != nil {
 			return fmt.Errorf("invalid ACL: %s", err)
 		}
 	}
 	if c.ACLMongo != nil {
 		if err := c.ACLMongo.Validate("acl_mongo"); err != nil {
+			return err
+		}
+	}
+	if c.ACLExt != nil {
+		if err := c.ACLExt.Validate(); err != nil {
 			return err
 		}
 	}

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -60,8 +60,8 @@ func NewAuthServer(c *Config) (*AuthServer, error) {
 		}
 		as.authorizers = append(as.authorizers, mongoAuthorizer)
 	}
-	if c.ACLExt != nil {
-		extAuthorizer := authz.NewACLExtAuthorizer(c.ACLExt)
+	if c.ExtAuthz != nil {
+		extAuthorizer := authz.NewExtAuthzAuthorizer(c.ExtAuthz)
 		as.authorizers = append(as.authorizers, extAuthorizer)
 	}
 	if c.Users != nil {

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -60,6 +60,10 @@ func NewAuthServer(c *Config) (*AuthServer, error) {
 		}
 		as.authorizers = append(as.authorizers, mongoAuthorizer)
 	}
+	if c.ACLExt != nil {
+		extAuthorizer := authz.NewACLExtAuthorizer(c.ACLExt)
+		as.authorizers = append(as.authorizers, extAuthorizer)
+	}
 	if c.Users != nil {
 		as.authenticators = append(as.authenticators, authn.NewStaticUserAuth(c.Users))
 	}

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -229,6 +229,6 @@ acl_mongo:
 # External authorization - call an external progam to authorize user.
 # JSON of authz.AuthRequestInfo is passed to command's stdin and exit code is examined.
 # 0 - allow, 1 - deny, other - error.
-acl_ext:
+ext_authz:
   command: "/usr/local/bin/my_authz"  # Can be a relative path too; $PATH works.
   args: ["--flag", "--more", "--flags"]

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -225,3 +225,10 @@ acl_mongo:
   # the MongoDB server.
   # (See https://golang.org/pkg/time/#ParseDuration for a format description.)
   cache_ttl: "1m"
+
+# External authorization - call an external progam to authorize user.
+# JSON of authz.AuthRequestInfo is passed to command's stdin and exit code is examined.
+# 0 - allow, 1 - deny, other - error.
+acl_ext:
+  command: "/usr/local/bin/my_authz"  # Can be a relative path too; $PATH works.
+  args: ["--flag", "--more", "--flags"]


### PR DESCRIPTION
PR for #142 
Added support to authorize request via an external script. The script returns a simple yes/no for the authz request through exit codes similarly to `ext_auth`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/143)
<!-- Reviewable:end -->
