### PR TITLE
Feature: GHE Support

### DIFF
--- a/auth_server/authn/data/github_auth.tmpl
+++ b/auth_server/authn/data/github_auth.tmpl
@@ -1,6 +1,6 @@
 <html itemscope itemtype="http://schema.org/Article">
 <body>
-  <button type="button" onclick="location.href='https://github.com/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}'">Login with GitHub</button>
-  <button type="button" onclick="location.href='https://github.com/settings/applications'">Revoke access</button>
+  <button type="button" onclick="location.href='{{.GithubWebUri}}/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}'">Login with GitHub</button>
+  <button type="button" onclick="location.href='{{.GithubWebUri}}/settings/applications'">Revoke access</button>
 </body>
 </html>

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -39,8 +39,8 @@ type GitHubAuthConfig struct {
 	TokenDB          string        `yaml:"token_db,omitempty"`
 	HTTPTimeout      time.Duration `yaml:"http_timeout,omitempty"`
 	RevalidateAfter  time.Duration `yaml:"revalidate_after,omitempty"`
-	GithubWebUri        string     `yaml:"github_web_uri,omitempty"`
-	GithubApiUri        string     `yaml:"github_api_uri,omitempty"`
+	GithubWebUri     string     `yaml:"github_web_uri,omitempty"`
+	GithubApiUri     string     `yaml:"github_api_uri,omitempty"`
 }
 
 type GitHubAuthRequest struct {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -39,8 +39,8 @@ type GitHubAuthConfig struct {
 	TokenDB          string        `yaml:"token_db,omitempty"`
 	HTTPTimeout      time.Duration `yaml:"http_timeout,omitempty"`
 	RevalidateAfter  time.Duration `yaml:"revalidate_after,omitempty"`
-	GithubWebUri     string     `yaml:"github_web_uri,omitempty"`
-	GithubApiUri     string     `yaml:"github_api_uri,omitempty"`
+	GithubWebUri     string        `yaml:"github_web_uri,omitempty"`
+	GithubApiUri     string        `yaml:"github_api_uri,omitempty"`
 }
 
 type GitHubAuthRequest struct {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -96,7 +96,7 @@ func (gha *GitHubAuth) getGithubApiUri() string {
 	if gha.config.GithubApiUri != "" {
 		return gha.config.GithubApiUri
 	} else {
-		return "api.github.com"
+		return "https://api.github.com"
 	}
 }
 
@@ -115,7 +115,7 @@ func (gha *GitHubAuth) doGitHubAuthCreateToken(rw http.ResponseWriter, code stri
 		"client_secret": []string{gha.config.ClientSecret},
 	}
 	
-	req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/login/oauth/access_token", gha.getGithubWebUri()), bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/login/oauth/access_token", gha.getGithubWebUri()), bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		http.Error(rw, fmt.Sprintf("Error creating request to GitHub auth backend: %s", err), http.StatusServiceUnavailable)
 		return
@@ -169,7 +169,7 @@ func (gha *GitHubAuth) doGitHubAuthCreateToken(rw http.ResponseWriter, code stri
 }
 
 func (gha *GitHubAuth) validateAccessToken(token string) (user string, err error) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/user", gha.getGithubApiUri()), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/user", gha.getGithubApiUri()), nil)
 	if err != nil {
 		err = fmt.Errorf("could not create request to get information for token %s: %s", token, err)
 		return
@@ -206,7 +206,7 @@ func (gha *GitHubAuth) checkOrganization(token, user string) (err error) {
 	if gha.config.Organization == "" {
 		return nil
 	}
-	url := fmt.Sprintf("https://%s/orgs/%s/members/%s", gha.getGithubApiUri(), gha.config.Organization, user)
+	url := fmt.Sprintf("%s/orgs/%s/members/%s", gha.getGithubApiUri(), gha.config.Organization, user)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		err = fmt.Errorf("could not create request to get organization membership: %s", err)

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -115,7 +115,7 @@ func (gha *GitHubAuth) doGitHubAuthCreateToken(rw http.ResponseWriter, code stri
 		"client_secret": []string{gha.config.ClientSecret},
 	}
 	
-	req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/login/oauth/access_token", getGithubWebUri()), bytes.NewBufferString(data.Encode()))
+	req, err := http.NewRequest("POST", fmt.Sprintf("https://%s/login/oauth/access_token", gha.getGithubWebUri()), bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		http.Error(rw, fmt.Sprintf("Error creating request to GitHub auth backend: %s", err), http.StatusServiceUnavailable)
 		return

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -85,11 +85,11 @@ github_auth:
   # How long to wait before revalidating the GitHub token. Optional.
   revalidate_after: "1h"
   # The Github Web URI in case you are using Github Enterprise.
-  # Includes the protocol, without trailing slash.
+  # Includes the protocol, without trailing slash. Optional - defaults to: https://github.com
   github_web_uri: "https://github.acme.com"
-  # The Github Web URI in case you are using Github Enterprise.
-  # Includes the protocol, without trailing slash.
-  github_api_uri: "https://github.acme.com/api/v3"
+  # The Github API URI in case you are using Github Enterprise.
+  # Includes the protocol, without trailing slash. - defaults to: https://api.github.com
+  github_api_uri: "https://github.acme.com/api/v3" 
 
 # LDAP authentication.
 # Authentication is performed by first binding to the server, looking up the user entry

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -84,6 +84,12 @@ github_auth:
   http_timeout: "10s"
   # How long to wait before revalidating the GitHub token. Optional.
   revalidate_after: "1h"
+  # The Github Web URI in case you are using Github Enterprise.
+  # Includes the protocol, without trailing slash.
+  github_web_uri: "https://github.acme.com"
+  # The Github Web URI in case you are using Github Enterprise.
+  # Includes the protocol, without trailing slash.
+  github_api_uri: "https://github.acme.com/api/v3"
 
 # LDAP authentication.
 # Authentication is performed by first binding to the server, looking up the user entry


### PR DESCRIPTION
Hey, based on #135 and @rojer `gh` branch I tried to enhance the solution. 

I think that it's way easier to split the Github API URI (needed for fetching user and org details from GH) and the Github Web URI (needed for the OAuth-Flow).   
github.com still remains the default. I also modified the github html template. 

Full disclosure: I am certainly no expert in Go (in fact, it's my first Go contribution). 

Please have a look and let me know whether this fits the needs or not. In the meantime, I am going to test it. 

Cheers,
Jan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/151)
<!-- Reviewable:end -->
