### PR TITLE
ldap_auth: An empty password worked for any valid user

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -54,7 +54,7 @@ func NewLDAPAuth(c *LDAPAuthConfig) (*LDAPAuth, error) {
 
 //How to authenticate user, please refer to https://github.com/go-ldap/ldap/blob/master/example_test.go#L166
 func (la *LDAPAuth) Authenticate(account string, password PasswordString) (bool, Labels, error) {
-	if account == "" {
+	if account == "" || password == "" {
 		return false, nil, NoMatch
 	}
 	l, err := la.ldapConnection()


### PR DESCRIPTION
See: go-ldap/ldap#93

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/155)
<!-- Reviewable:end -->
