### PR TITLE
Quick fix so user knows that he should set registry fqdn

### DIFF
--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -165,7 +165,7 @@ func (gha *GitHubAuth) doGitHubAuthCreateToken(rw http.ResponseWriter, code stri
 		return
 	}
 
-	fmt.Fprintf(rw, `Server logged in; now run "docker login", use %s as login and %s as password.`, user, dp)
+	fmt.Fprintf(rw, `Server logged in; now run "docker login YOUR_REGISTRY_FQDN", use %s as login and %s as password.`, user, dp)
 }
 
 func (gha *GitHubAuth) validateAccessToken(token string) (user string, err error) {

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -234,7 +234,7 @@ func (ga *GoogleAuth) doGoogleAuthCreateToken(rw http.ResponseWriter, code strin
 		return
 	}
 
-	fmt.Fprintf(rw, `Server logged in; now run "docker login", use %s as login and %s as password.`, user, dp)
+	fmt.Fprintf(rw, `Server logged in; now run "docker login YOUR_REGISTRY_FQDN", use %s as login and %s as password.`, user, dp)
 }
 
 func (ga *GoogleAuth) getIDTokenInfo(token string) (*GoogleTokenInfo, error) {


### PR DESCRIPTION
Ref.: https://github.com/cesanta/docker_auth/issues/157

Say `docker login YOUR_REGISTRY_FQDN` as a quick n dirty fix so the user knows that he should set its registry url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/158)
<!-- Reviewable:end -->
