### PR TITLE
fix the "file not exist" problem

### DIFF
--- a/examples/ext_auth.sh
+++ b/examples/ext_auth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Example external authenticator program for use with `ext_auth`.
 #


### PR DESCRIPTION
using the ext_auth example script in the `stable` image  
docker logs will always show `files not exist` error  
replace the `#!/bin/bash` by `#!/bin/sh` will fix this problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/159)
<!-- Reviewable:end -->
