### PR TITLE
Fixed simple mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Supported authorization methods:
 
 ## Installation and Examples
 
-A public Docker image is available on Docker Hub: [cesanta/docker](https://registry.hub.docker.com/u/cesanta/docker_auth/).
+A public Docker image is available on Docker Hub: [cesanta/docker_auth](https://registry.hub.docker.com/u/cesanta/docker_auth/).
 
 Tags available:
  - `:latest` - bleeding edge, usually works but breaking config changes are possible. You probably do not want to use this in production.


### PR DESCRIPTION
In text the link to the container was cesanta/docker, while it should (have) been cesanta/docker_auth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/164)
<!-- Reviewable:end -->
