### PR TITLE
Map LDAP account attributes to labels such as groups #63

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -40,8 +40,6 @@ type LDAPAuthConfig struct {
 	BindDN                string              `yaml:"bind_dn,omitempty"`
 	BindPasswordFile      string              `yaml:"bind_password_file,omitempty"`
 	LabelMaps             map[string]LabelMap `yaml:"labels,omitempty"`
-	GroupBaseDN           string              `yaml:"group_base_dn,omitempty"`
-	GroupFilter           string              `yaml:"group_filter,omitempty"`
 }
 
 type LDAPAuth struct {

--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -26,16 +26,22 @@ import (
 	"github.com/golang/glog"
 )
 
+type LabelMap struct {
+	Attribute string `yaml:"attribute,omitempty"`
+	ParseCN   bool   `yaml:"parse_cn,omitempty"`
+}
+
 type LDAPAuthConfig struct {
-	Addr                  string `yaml:"addr,omitempty"`
-	TLS                   string `yaml:"tls,omitempty"`
-	InsecureTLSSkipVerify bool   `yaml:"insecure_tls_skip_verify,omitempty"`
-	Base                  string `yaml:"base,omitempty"`
-	Filter                string `yaml:"filter,omitempty"`
-	BindDN                string `yaml:"bind_dn,omitempty"`
-	BindPasswordFile      string `yaml:"bind_password_file,omitempty"`
-	GroupBaseDN           string `yaml:"group_base_dn,omitempty"`
-	GroupFilter           string `yaml:"group_filter,omitempty"`
+	Addr                  string              `yaml:"addr,omitempty"`
+	TLS                   string              `yaml:"tls,omitempty"`
+	InsecureTLSSkipVerify bool                `yaml:"insecure_tls_skip_verify,omitempty"`
+	Base                  string              `yaml:"base,omitempty"`
+	Filter                string              `yaml:"filter,omitempty"`
+	BindDN                string              `yaml:"bind_dn,omitempty"`
+	BindPasswordFile      string              `yaml:"bind_password_file,omitempty"`
+	LabelMaps             map[string]LabelMap `yaml:"labels,omitempty"`
+	GroupBaseDN           string              `yaml:"group_base_dn,omitempty"`
+	GroupFilter           string              `yaml:"group_filter,omitempty"`
 }
 
 type LDAPAuth struct {
@@ -71,22 +77,19 @@ func (la *LDAPAuth) Authenticate(account string, password PasswordString) (bool,
 
 	filter := la.getFilter(account)
 
-	// dnAndGroupAttr := []string{"DN"} // example of no groups mapping attribute
-	groupAttribute := "memberOf"
-	dnAndGroupAttr := []string{"DN", groupAttribute}
+	labelAttributes, labelsConfigErr := la.getLabelAttributes()
+	if labelsConfigErr != nil {
+		return false, nil, labelsConfigErr
+	}
 
-	entryAttrMap, uSearchErr := la.ldapSearch(l, &la.config.Base, &filter, &dnAndGroupAttr)
+	accountEntryDN, entryAttrMap, uSearchErr := la.ldapSearch(l, &la.config.Base, &filter, &labelAttributes)
 	if uSearchErr != nil {
 		return false, nil, uSearchErr
 	}
-	if len(entryAttrMap) < 1 || entryAttrMap["DN"] == nil || len(entryAttrMap["DN"]) != 1 {
-		return false, nil, NoMatch // User does not exist
-	}
-
-	accountEntryDN := entryAttrMap["DN"][0]
 	if accountEntryDN == "" {
 		return false, nil, NoMatch // User does not exist
 	}
+
 	// Bind as the user to verify their password
 	if len(accountEntryDN) > 0 {
 		err := l.Bind(accountEntryDN, string(password))
@@ -102,21 +105,13 @@ func (la *LDAPAuth) Authenticate(account string, password PasswordString) (bool,
 		return false, nil, bindErr
 	}
 
-	// Extract group names from the attribute values
-	if entryAttrMap[groupAttribute] != nil {
-		rawGroups := entryAttrMap[groupAttribute]
-		labels := make(map[string][]string)
-		var groups []string
-		for _, value := range rawGroups {
-			cn := la.getCNFromDN(value)
-			groups = append(groups, cn)
-		}
-		labels["groups"] = groups
-
-		return true, labels, nil
+	// Extract labels from the attribute values
+	labels, labelsExtractErr := la.getLabelsFromMap(entryAttrMap)
+	if labelsExtractErr != nil {
+		return false, nil, labelsExtractErr
 	}
 
-	return true, nil, nil
+	return true, labels, nil
 }
 
 func (la *LDAPAuth) bindReadOnlyUser(l *ldap.Conn) error {
@@ -193,9 +188,9 @@ func (la *LDAPAuth) getFilter(account string) string {
 
 //ldap search and return required attributes' value from searched entries
 //default return entry's DN value if you leave attrs array empty
-func (la *LDAPAuth) ldapSearch(l *ldap.Conn, baseDN *string, filter *string, attrs *[]string) (map[string][]string, error) {
+func (la *LDAPAuth) ldapSearch(l *ldap.Conn, baseDN *string, filter *string, attrs *[]string) (string, map[string][]string, error) {
 	if l == nil {
-		return nil, fmt.Errorf("No ldap connection!")
+		return "", nil, fmt.Errorf("No ldap connection!")
 	}
 	glog.V(2).Infof("Searching...basedDN:%s, filter:%s", *baseDN, *filter)
 	searchRequest := ldap.NewSearchRequest(
@@ -206,38 +201,66 @@ func (la *LDAPAuth) ldapSearch(l *ldap.Conn, baseDN *string, filter *string, att
 		nil)
 	sr, err := l.Search(searchRequest)
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 
 	if len(sr.Entries) == 0 {
-		return nil, nil // User does not exist
+		return "", nil, nil // User does not exist
 	} else if len(sr.Entries) > 1 {
-		return nil, fmt.Errorf("Too many entries returned.")
+		return "", nil, fmt.Errorf("Too many entries returned.")
 	}
 
-	result := make(map[string][]string)
+	attributes := make(map[string][]string)
+	var entryDn string
 	for _, entry := range sr.Entries {
-
+		entryDn = entry.DN
 		if len(*attrs) == 0 {
-			glog.V(2).Infof("Entry DN = %s", entry.DN)
-			result["DN"] = []string{entry.DN}
+			glog.V(2).Infof("Entry DN = %s", entryDn)
 		} else {
 			for _, attr := range *attrs {
-				var values []string
-				if attr == "DN" {
-					// DN is excluded from attributes
-					values = []string{entry.DN}
-				} else {
-					values = entry.GetAttributeValues(attr)
-				}
-				valuesString := strings.Join(values, "\n")
-				glog.V(2).Infof("Entry %s = %s", attr, valuesString)
-				result[attr] = values
+				values := entry.GetAttributeValues(attr)
+				glog.V(2).Infof("Entry %s = %s", attr, strings.Join(values, "\n"))
+				attributes[attr] = values
 			}
 		}
 	}
 
-	return result, nil
+	return entryDn, attributes, nil
+}
+
+func (la *LDAPAuth) getLabelAttributes() ([]string, error) {
+	labelAttributes := make([]string, len(la.config.LabelMaps))
+	i := 0
+	for key, mapping := range la.config.LabelMaps {
+		if mapping.Attribute == "" {
+			return nil, fmt.Errorf("Label %s is missing 'attribute' to map from", key)
+		}
+		labelAttributes[i] = mapping.Attribute
+		i++
+	}
+	return labelAttributes, nil
+}
+
+func (la *LDAPAuth) getLabelsFromMap(attrMap map[string][]string) (map[string][]string, error) {
+	labels := make(map[string][]string)
+	for key, mapping := range la.config.LabelMaps {
+		if mapping.Attribute == "" {
+			return nil, fmt.Errorf("Label %s is missing 'attribute' to map from", key)
+		}
+
+		mappingValues := attrMap[mapping.Attribute]
+		if mappingValues != nil {
+			if mapping.ParseCN {
+				// shorten attribute to its common name
+				for i, value := range mappingValues {
+					cn := la.getCNFromDN(value)
+					mappingValues[i] = cn
+				}
+			}
+			labels[key] = mappingValues
+		}
+	}
+	return labels, nil
 }
 
 func (la *LDAPAuth) getCNFromDN(dn string) string {

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -134,6 +134,16 @@ ldap_auth:
   # User query settings. ${account} is expanded from auth request 
   base: o=example.com
   filter: (&(uid=${account})(objectClass=person))
+  # Labels can be mapped from LDAP attributes
+  labels:
+    # Add the user's title to a label called title
+    title:
+      attribute: title
+    # Add the user's memberOf values to a label called groups
+    groups:
+      attribute: memberOf
+      # Special handling to simplify the values to just the common name
+      parse_cn: true
 
 mongo_auth:
   # Essentially all options are described here: https://godoc.org/gopkg.in/mgo.v2#DialInfo


### PR DESCRIPTION
**Updated:**

I am proposing a configurable structure to leverage ldap account attributes as labels for access control. Let me know what you think.

I have added a `labels` mapping to the configuration, for example:
```
ldap_auth:
  ...
  filter: (&(|(userPrincipalName=${account})(userPrincipalName=${account}@example.com)(mail=${account}))(objectClass=person))
  labels:
    groups:
      attribute: memberOf
      parse_cn: true
    title:
      attribute: title
```

Can then be used with the current labels implementation like so:

```
 acl:
  - match: {labels: {"title": "Developer"}}
    actions: ["*"]
    comment: "If you call yourself a developer you can do anything."
  - match: {labels: {"groups": "Admin"}}
    actions: ["push"]
    comment: "If you are part of the admin group you can push."	
```
	
Using title for an acl is probably a really dumb idea. But it proves you can map arbitary attributes to arbitary labels. 

There is one special option, `parse_cn` which extracts the common name from a fully qualified value as found in `memberOf`.


**Original:**

I know little about LDAP and even less GO but I've taken the labels approach in #139 and populated groups to address #63.

```
  - match: {name: "docker_auth", labels: {"groups": "Admin"}}
    actions: ["*"]
    comment: "Admin users can do anything to docker_auth."
```

I'm simply looking through the account response for `memberOf` details. The alternative approach for ldap would be to look up groups and find member accounts.

A similar approach might be useful for #117

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/167)
<!-- Reviewable:end -->
