### PR TITLE
Fix checking of service field in ACL.

### DIFF
--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -27,6 +27,7 @@ type MatchConditions struct {
 	Type    *string           `yaml:"type,omitempty" json:"type,omitempty"`
 	Name    *string           `yaml:"name,omitempty" json:"name,omitempty"`
 	IP      *string           `yaml:"ip,omitempty" json:"ip,omitempty"`
+	Service *string           `yaml:"service,omitempty" json:"service,omitempty"`
 	Labels  map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 }
 
@@ -64,7 +65,7 @@ func parseIPPattern(ipp string) (*net.IPNet, error) {
 }
 
 func validateMatchConditions(mc *MatchConditions) error {
-	for _, p := range []*string{mc.Account, mc.Type, mc.Name} {
+	for _, p := range []*string{mc.Account, mc.Type, mc.Name, mc.Service} {
 		if p == nil {
 			continue
 		}
@@ -201,7 +202,7 @@ func (mc *MatchConditions) Matches(ai *AuthRequestInfo) bool {
 		"${name}", regexp.QuoteMeta(ai.Name),
 		"${service}", regexp.QuoteMeta(ai.Service),
 	}
-	for _, x := range []string{"Account", "Type", "Name"} {
+	for _, x := range []string{"Account", "Type", "Name", "Service"} {
 		field, _ := getField(mc, x)
 		for _, found := range captureGroupRegex.FindAllStringSubmatch(field, -1) {
 			key := strings.Title(found[1])
@@ -235,6 +236,7 @@ func (mc *MatchConditions) Matches(ai *AuthRequestInfo) bool {
 	return matchString(mc.Account, ai.Account, vars) &&
 		matchString(mc.Type, ai.Type, vars) &&
 		matchString(mc.Name, ai.Name, vars) &&
+		matchString(mc.Service, ai.Service, vars) &&
 		matchIP(mc.IP, ai.IP) &&
 		matchLabels(mc.Labels, ai.Labels, vars)
 }

--- a/auth_server/authz/acl_test.go
+++ b/auth_server/authz/acl_test.go
@@ -25,6 +25,9 @@ func TestValidation(t *testing.T) {
 		{MatchConditions{Name: sp("foo")}, true},
 		{MatchConditions{Name: sp("foo?*")}, true},
 		{MatchConditions{Name: sp("/foo.*/")}, true},
+		{MatchConditions{Service: sp("foo")}, true},
+		{MatchConditions{Service: sp("foo?*")}, true},
+		{MatchConditions{Service: sp("/foo.*/")}, true},
 		{MatchConditions{IP: sp("192.168.0.1")}, true},
 		{MatchConditions{IP: sp("192.168.0.0/16")}, true},
 		{MatchConditions{IP: sp("2001:db8::1")}, true},
@@ -34,6 +37,7 @@ func TestValidation(t *testing.T) {
 		{MatchConditions{Account: sp("/foo?*/")}, false},
 		{MatchConditions{Type: sp("/foo?*/")}, false},
 		{MatchConditions{Name: sp("/foo?*/")}, false},
+		{MatchConditions{Service: sp("/foo?*/")}, false},
 		{MatchConditions{IP: sp("192.168.0.1/100")}, false},
 		{MatchConditions{IP: sp("192.168.0.*")}, false},
 		{MatchConditions{IP: sp("foo")}, false},
@@ -51,8 +55,8 @@ func TestValidation(t *testing.T) {
 }
 
 func TestMatching(t *testing.T) {
-	ai1 := AuthRequestInfo{Account: "foo", Type: "bar", Name: "baz"}
-	ai2 := AuthRequestInfo{Account: "foo", Type: "bar", Name: "baz",
+	ai1 := AuthRequestInfo{Account: "foo", Type: "bar", Name: "baz", Service: "notary"}
+	ai2 := AuthRequestInfo{Account: "foo", Type: "bar", Name: "baz", Service: "notary",
 		Labels: map[string][]string{"group": []string{"admins", "VIP"}}}
 	cases := []struct {
 		mc      MatchConditions
@@ -71,6 +75,9 @@ func TestMatching(t *testing.T) {
 		{MatchConditions{Account: sp(`/^(.+)@test\.com$/`), Name: sp(`${account:1}/*`)}, AuthRequestInfo{Account: "john.smith@test.com", Name: "john.smith/test"}, true},
 		{MatchConditions{Account: sp(`/^(.+)@test\.com$/`), Name: sp(`${account:3}/*`)}, AuthRequestInfo{Account: "john.smith@test.com", Name: "john.smith/test"}, false},
 		{MatchConditions{Account: sp(`/^(.+)@(.+?).test\.com$/`), Name: sp(`${account:1}-${account:2}/*`)}, AuthRequestInfo{Account: "john.smith@it.test.com", Name: "john.smith-it/test"}, true},
+		{MatchConditions{Service: sp("notary"), Type: sp("bar")}, ai1, true},
+		{MatchConditions{Service: sp("notary"), Type: sp("baz")}, ai1, false},
+		{MatchConditions{Service: sp("notary1"), Type: sp("bar")}, ai1, false},
 		// IP matching
 		{MatchConditions{IP: sp("127.0.0.1")}, AuthRequestInfo{IP: nil}, false},
 		{MatchConditions{IP: sp("127.0.0.1")}, AuthRequestInfo{IP: net.IPv4(127, 0, 0, 1)}, true},


### PR DESCRIPTION
There is `service` field to define in the ACL, however the code misses to check it.
This PR fixes this so you can have the rules like this:
```
  - match: {account: "", service: "notary.quiq.sh"}
    actions: ["pull"]
    comment: "Anonymous users can get signatures from notary."
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/170)
<!-- Reviewable:end -->
