### PR TITLE
Add a Note regarding OAuth and Third-Party Cookies

### DIFF
--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -73,7 +73,8 @@ google_auth:
   domain: "example.com"  # Optional. If set, only logins from this domain are accepted.
   # client_id and client_secret for API access. Required.
   # Follow instructions here: https://developers.google.com/identity/sign-in/web/devconsole-project
-  # NB: Make sure JavaScript origins are configured correctly.
+  # NB: Make sure JavaScript origins are configured correctly, and that third-party
+  # cookies are not blocked in the browser being used to login.
   client_id: "1223123456-somethingsomething.apps.googleusercontent.com"
   # Either client_secret or client_secret_file is required. Use client_secret_file if you don't
   # want to have sensitive information checked in.
@@ -93,7 +94,8 @@ github_auth:
   organization: "acme"   # Optional. If set, only logins from this organization are accepted.
   # client_id and client_secret for API access. Required.
   # You can register a new application here: https://github.com/settings/developers
-  # NB: Make sure JavaScript origins are configured correctly.
+  # NB: Make sure JavaScript origins are configured correctly, and that third-party
+  # cookies are not blocked in the browser being used to login.
   client_id: "1223123456"
   # Either client_secret or client_secret_file is required. Use client_secret_file if you don't
   # want to have sensitive information checked in.


### PR DESCRIPTION
When using the Google or GitHub (or really any) OAuth method, the browser you use cannot have third party cookies blocked. If they are, the authentication will fail and it will feel as if the calls are going to the wrong places. 

This commit adds a little note in the configuration, so it's immediately apparent to the developer testing their setup. In other words, this would have saved me an hour 😉 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/187)
<!-- Reviewable:end -->
