### PR TITLE
docker_auth/github: pass read:org scope for the authorization

### DIFF
--- a/auth_server/authn/data/github_auth.tmpl
+++ b/auth_server/authn/data/github_auth.tmpl
@@ -1,6 +1,6 @@
 <html itemscope itemtype="http://schema.org/Article">
 <body>
-  <button type="button" onclick="location.href='{{.GithubWebUri}}/login/oauth/authorize?scope=user:email&client_id={{.ClientId}}'">Login with GitHub</button>
+  <button type="button" onclick="location.href='{{.GithubWebUri}}/login/oauth/authorize?scope=user:email%20read:org&client_id={{.ClientId}}'">Login with GitHub</button>
   <button type="button" onclick="location.href='{{.GithubWebUri}}/settings/applications'">Revoke access</button>
 </body>
 </html>


### PR DESCRIPTION
The read:org scope is required for the authorization as it allows user to check whether it's a member of the organization or not.

GitHub Scopes for OAuth Apps are described:
https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-scopes-for-oauth-apps/

Fixes #189

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/190)
<!-- Reviewable:end -->
