### PR TITLE
docker_auth/github: store tokens in google cloud storage

### DIFF
--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -24,8 +24,8 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
-	"github.com/dchest/uniuri"
 	"github.com/cesanta/glog"
+	"github.com/dchest/uniuri"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -93,7 +93,7 @@ func (db *TokenDBImpl) GetValue(user string) (*TokenDBValue, error) {
 	err = json.Unmarshal(valueStr, &dbv)
 	if err != nil {
 		glog.Errorf("bad DB value for %q (%q): %s", user, string(valueStr), err)
-		return nil, fmt.Errorf("bad DB value", err)
+		return nil, fmt.Errorf("bad DB value due: %v", err)
 	}
 	return &dbv, nil
 }

--- a/auth_server/authn/tokendb_gcs.go
+++ b/auth_server/authn/tokendb_gcs.go
@@ -1,0 +1,121 @@
+/*
+   Copyright 2017 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/cesanta/glog"
+	"github.com/dchest/uniuri"
+	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/net/context"
+	"google.golang.org/api/option"
+)
+
+// NewGCSTokenDB return a new TokenDB structure which uses Google Cloud Storage as backend. The
+// created DB uses file-per-user strategy and stores credentials independently for each user.
+//
+// Note: it's not recomanded bucket to be shared with other apps or services
+func NewGCSTokenDB(bucket, clientSecretFile string) (TokenDB, error) {
+	gcs, err := storage.NewClient(context.Background(), option.WithServiceAccountFile(clientSecretFile))
+	return &gcsTokenDB{gcs, bucket}, err
+}
+
+type gcsTokenDB struct {
+	gcs    *storage.Client
+	bucket string
+}
+
+// GetValue gets token value associated with the provided user. Each user
+// in the bucket is having it's own file for tokens and it's recomanded bucket
+// to not be shared with other apps
+func (db *gcsTokenDB) GetValue(user string) (*TokenDBValue, error) {
+	rd, err := db.gcs.Bucket(db.bucket).Object(user).NewReader(context.Background())
+	if err == storage.ErrObjectNotExist {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieved token for user '%s' due: %v", user, err)
+	}
+	defer rd.Close()
+
+	var dbv TokenDBValue
+	if err := json.NewDecoder(rd).Decode(&dbv); err != nil {
+		glog.Errorf("bad DB value for %q: %v", user, err)
+		return nil, fmt.Errorf("could not read token for user '%s' due: %v", user, err)
+	}
+
+	return &dbv, nil
+}
+
+// StoreToken stores token in the GCS file in a JSON format. Note that separate file is
+// used for each user
+func (db *gcsTokenDB) StoreToken(user string, v *TokenDBValue, updatePassword bool) (dp string, err error) {
+	if updatePassword {
+		dp = uniuri.New()
+		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), bcrypt.DefaultCost)
+		v.DockerPassword = string(dph)
+	}
+
+	wr := db.gcs.Bucket(db.bucket).Object(user).NewWriter(context.Background())
+
+	if err := json.NewEncoder(wr).Encode(v); err != nil {
+		glog.Errorf("failed to set token data for %s: %s", user, err)
+		return "", fmt.Errorf("failed to set token data for %s due: %v", user, err)
+	}
+
+	err = wr.Close()
+	return
+}
+
+// ValidateToken verifies whether the provided token passed as password field
+// is still valid, e.g available and not expired
+func (db *gcsTokenDB) ValidateToken(user string, password PasswordString) error {
+	dbv, err := db.GetValue(user)
+	if err != nil {
+		return err
+	}
+	if dbv == nil {
+		return NoMatch
+	}
+
+	if bcrypt.CompareHashAndPassword([]byte(dbv.DockerPassword), []byte(password)) != nil {
+		return WrongPass
+	}
+	if time.Now().After(dbv.ValidUntil) {
+		return ExpiredToken
+	}
+
+	return nil
+}
+
+// DeleteToken deletes the GCS file that is associated with the provided user.
+func (db *gcsTokenDB) DeleteToken(user string) error {
+	ctx := context.Background()
+	err := db.gcs.Bucket(db.bucket).Object(user).Delete(ctx)
+	if err == storage.ErrObjectNotExist {
+		return nil
+	}
+	return err
+}
+
+// Close is a nop operation for this db
+func (db *gcsTokenDB) Close() error {
+	return nil
+}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -120,8 +120,12 @@ func validate(c *Config) error {
 			}
 			ghac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || ghac.TokenDB == "" {
-			return errors.New("github_auth.{client_id,client_secret,token_db} are required.")
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.TokenDB == "" && ghac.GCSTokenDB == nil) {
+			return errors.New("github_auth.{client_id,client_secret,token_db} are required")
+		}
+
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.GCSTokenDB != nil && (ghac.GCSTokenDB.Bucket == "" || ghac.GCSTokenDB.ClientSecretFile == "")) {
+			return errors.New("github_auth.{client_id,client_secret,gcs_token_db{bucket,client_secret_file}} are required")
 		}
 		if ghac.HTTPTimeout <= 0 {
 			ghac.HTTPTimeout = time.Duration(10 * time.Second)

--- a/auth_server/vendor/vendor.json
+++ b/auth_server/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "",
 	"package": [
 		{
+			"checksumSHA1": "0ot8Hk23WGrT0lE2BmQXeqe4bRo=",
+			"path": "cloud.google.com/go/storage",
+			"revision": "2b74e2e25316cfd9e46b74e444cdeceb78786dc5",
+			"revisionTime": "2017-08-20T12:51:33Z"
+		},
+		{
 			"checksumSHA1": "CujWu7+PWlZSX5+zAPJH91O5AVQ=",
 			"origin": "github.com/docker/distribution/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
@@ -397,10 +403,16 @@
 			"revisionTime": "2017-03-21T17:14:25Z"
 		},
 		{
-			"checksumSHA1": "AK65RmsGNBl0/e11OVrf2mW78gU=",
+			"checksumSHA1": "1WoWjPiwUEFahi5xz29FRMtd8sA=",
 			"path": "golang.org/x/sys/unix",
 			"revision": "493114f68206f85e7e333beccfabc11e98cba8dd",
 			"revisionTime": "2017-03-31T21:25:38Z"
+		},
+		{
+			"checksumSHA1": "RpAaByicZuXzN7bReX8YXKf8gP0=",
+			"path": "google.golang.org/api/option",
+			"revision": "955a3ae66b420f3adc0d77da3d8ed767a74e2b4f",
+			"revisionTime": "2017-09-01T00:04:07Z"
 		},
 		{
 			"checksumSHA1": "fRERF7JFq7KYgM9I48onMlEgFm4=",

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -101,8 +101,12 @@ github_auth:
   # want to have sensitive information checked in.
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
-  # Where to store server tokens. Required.
+  # Either token_db file for storing of server tokens. 
   token_db: "/somewhere/to/put/github_tokens.ldb"
+  # or google cloud storage for storing of the sensitive information. 
+  gcs_token_db: 
+    bucket: "tokenBucket"
+    client_secret_file: "/path/to/client_secret.json"
   # How long to wait when talking to GitHub servers. Optional.
   http_timeout: "10s"
   # How long to wait before revalidating the GitHub token. Optional.


### PR DESCRIPTION
Added a new implementation of TokenDB that uses Google Cloud Storage as backend for storing of the tokens.

This makes container independent from the file system of the container or from the target system and is good alternative to mounted clustered file systems to container.

Docs examples are updated regarding this change as specifying token_db configuration now becomes alternate between local file and gcs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/193)
<!-- Reviewable:end -->
