### PR TITLE
Set custom CA certificate for ldap cert verification

### DIFF
--- a/examples/ldap_auth.yml
+++ b/examples/ldap_auth.yml
@@ -18,6 +18,8 @@ ldap_auth:
   tls: always
   # set to true to allow insecure tls
   insecure_tls_skip_verify: false
+  # set this to specify the ca certificate path
+  ca_certificate:
   # In case bind DN and password is required for querying user information,
   # specify them here. Plain text password is read from the file.
   bind_dn:

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -131,6 +131,8 @@ ldap_auth:
   tls: always
   # set to true to allow insecure tls
   insecure_tls_skip_verify: false
+  # set this to specify the ca certificate path
+  ca_certificate:
   # In case bind DN and password is required for querying user information,
   # specify them here. Plain text password is read from the file.
   bind_dn:


### PR DESCRIPTION
Sometimes the signing CA for LDAP is not in the certs directory golang looks into, this PR provides support for using a custom filepath to load the CA to verify the LDAP cert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/197)
<!-- Reviewable:end -->
