### PR TITLE
Add OS X Hash Generation Instruction

### DIFF
--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -58,6 +58,7 @@ token:  # Settings for the tokens.
 # Static user map.
 users:
   # Password is specified as a BCrypt hash. Use htpasswd -B to generate.
+  # or `htpasswd -nB $USERNAME` on OS X
   "admin":
     password: "$2y$05$LO.vzwpWC5LZGqThvEfznu8qhb5SGqvBSWY1J3yZ4AxtMRZ3kN5jC"  # badmin
   "test":

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -18,6 +18,7 @@ token:
 
 users:
   # Password is specified as a BCrypt hash. Use htpasswd -B to generate.
+  # or `htpasswd -nB $USERNAME` on OS X
   "admin":
     password: "$2y$05$LO.vzwpWC5LZGqThvEfznu8qhb5SGqvBSWY1J3yZ4AxtMRZ3kN5jC"  # badmin
   "test":


### PR DESCRIPTION
On OS X you can generate a bcrypt hash by running `htpasswd -nB $USERNAME`.

The initial comment may work on Linux systems, but if you're developing on a Mac, it may help to have this extra line (I know it helps my team).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/203)
<!-- Reviewable:end -->
