### PR TITLE
Add support for Keycloak Direct Grant authentication

### DIFF
--- a/auth_server/authn/keycloak_direct_auth.go
+++ b/auth_server/authn/keycloak_direct_auth.go
@@ -1,0 +1,114 @@
+/*
+   Copyright 2015 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cesanta/glog"
+)
+
+type KeycloakDirectGrantAuthConfig struct {
+	URI              string        `yaml:"uri"`
+	Realm            string        `yaml:"realm"`
+	ClientID         string        `yaml:"client_id"`
+	ClientSecret     string        `yaml:"client_secret"`
+	ClientSecretFile string        `yaml:"client_secret_file,omitempty"`
+	HTTPTimeout      time.Duration `yaml:"http_timeout,omitempty"`
+}
+
+type KeycloakDirectGrantAuth struct {
+	config *KeycloakDirectGrantAuthConfig
+	client *http.Client
+}
+
+// TokenResponse is sent by Keycloak server in response to the grant_type=password request.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token,omitempty"`
+	RefreshToken string `json:"refresh_token,omitempty"`
+	ExpiresIn    int64  `json:"expires_in,omitempty"`
+	TokenType    string `json:"token_type,omitempty"`
+	SessionState string `json:"session_state,omitempty"`
+	// Returned in case of error.
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+func NewKeycloakDirectGrantAuth(c *KeycloakDirectGrantAuthConfig) *KeycloakDirectGrantAuth {
+	return &KeycloakDirectGrantAuth{
+		config: c,
+		client: &http.Client{Timeout: c.HTTPTimeout * time.Second},
+	}
+}
+
+func (kauth *KeycloakDirectGrantAuth) Authenticate(user string, password PasswordString) (bool, Labels, error) {
+	err := kauth.validateAccount(user, password)
+	if err != nil {
+		return false, nil, err
+	}
+	return true, nil, nil
+}
+
+func (kauth *KeycloakDirectGrantAuth) validateAccount(user string, password PasswordString) error {
+	uri := fmt.Sprintf("%s/auth/realms/%s/protocol/openid-connect/token", kauth.config.URI, kauth.config.Realm)
+	v := url.Values{
+		"client_id":  []string{kauth.config.ClientID},
+		"grant_type": []string{"password"},
+		"username":   []string{user},
+		"password":   []string{string(password)},
+	}
+	if kauth.config.ClientSecret != "" {
+		v.Set("client_secret", kauth.config.ClientSecret)
+	}
+	resp, err := kauth.client.PostForm(uri, v)
+	if err != nil {
+		err = fmt.Errorf("Error talking to Keycloak: %s", err)
+		return err
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return WrongPass
+	}
+	var tr TokenResponse
+	err = json.Unmarshal(body, &tr)
+	if err != nil || tr.Error != "" || tr.ErrorDescription != "" {
+		var et string
+		if err != nil {
+			et = err.Error()
+		} else {
+			et = fmt.Sprintf("%s: %s", tr.Error, tr.ErrorDescription)
+		}
+		err = fmt.Errorf("Failed to authenticate(%s): %s", resp.Status, et)
+		return err
+	}
+	glog.V(2).Infof("Token info: %+v", strings.Replace(string(body), "\n", " ", -1))
+	return nil
+}
+
+func (kauth *KeycloakDirectGrantAuth) Stop() {
+}
+
+func (kauth *KeycloakDirectGrantAuth) Name() string {
+	return "KeycloakDirectGrant"
+}

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -91,6 +91,10 @@ func NewAuthServer(c *Config) (*AuthServer, error) {
 		as.authenticators = append(as.authenticators, gha)
 		as.gha = gha
 	}
+	if c.KeycloakDirectGrantAuth != nil {
+		as.authenticators = append(as.authenticators,
+			authn.NewKeycloakDirectGrantAuth(c.KeycloakDirectGrantAuth))
+	}
 	if c.LDAPAuth != nil {
 		la, err := authn.NewLDAPAuth(c.LDAPAuth)
 		if err != nil {
@@ -334,13 +338,13 @@ func (as *AuthServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	glog.V(3).Infof("Request: %+v", req)
 	path_prefix := as.config.Server.PathPrefix
 	switch {
-	case req.URL.Path == path_prefix + "/":
+	case req.URL.Path == path_prefix+"/":
 		as.doIndex(rw, req)
-	case req.URL.Path == path_prefix + "/auth":
+	case req.URL.Path == path_prefix+"/auth":
 		as.doAuth(rw, req)
-	case req.URL.Path == path_prefix + "/google_auth" && as.ga != nil:
+	case req.URL.Path == path_prefix+"/google_auth" && as.ga != nil:
 		as.ga.DoGoogleAuth(rw, req)
-	case req.URL.Path == path_prefix + "/github_auth" && as.gha != nil:
+	case req.URL.Path == path_prefix+"/github_auth" && as.gha != nil:
 		as.gha.DoGitHubAuth(rw, req)
 	default:
 		http.Error(rw, "Not found", http.StatusNotFound)

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -118,6 +118,24 @@ github_auth:
   # Includes the protocol, without trailing slash. - defaults to: https://api.github.com
   github_api_uri: "https://github.acme.com/api/v3" 
 
+# Keycloak direct grant authentication.
+# The keycloak client has to have the "Direct Access Grants Enabled" option enabled.
+keycloak_direct_grant_auth:
+  # The keycloak URI. Required.
+  # Includes the protocol, without trailing slash.
+  uri: "https://my.keycloak.com"
+  # Realm name that will be used on the Keycloak. Required.
+  realm: "master"
+  # client_id that will be used on the Keycloak. Required.
+  client_id: "1223123456"
+  # Either client_secret or client_secret_file is required if the client is configured for
+  # confidential access type. Use client_secret_file if you don't want to have
+  # sensitive information checked in.
+  # client_secret: "verysecret"
+  client_secret_file: "/path/to/client_secret.txt"
+  # How long (in seconds) to wait when talking to Keycloak servers. Optional - defaults to: 10
+  http_timeout: 10
+
 # LDAP authentication.
 # Authentication is performed by first binding to the server, looking up the user entry
 # by using the specified filter, and then re-binding using the matched DN and the password provided.


### PR DESCRIPTION
Add support for Keycloak Direct Grant(Resource Owner Password Credentials Grant in the OAuth 2.0).
http://www.keycloak.org/docs/latest/securing_apps/index.html#_resource_owner_password_credentials_flow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/208)
<!-- Reviewable:end -->
