### PR TITLE
added config settings to share letsencrypt.json with registry so both can run on same machine

### DIFF
--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --warn-undefined-variables
-IMAGE ?= cesanta/docker_auth
+IMAGE ?= checker/docker_auth
 COMPRESS_BINARY ?= false
 CA_BUNDLE = /etc/ssl/certs/ca-bundle.crt
 VERSION = $(shell cat version.txt)

--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables
 IMAGE ?= cesanta/docker_auth
 COMPRESS_BINARY ?= false
-CA_BUNDLE = /etc/ssl/certs/ca-certificates.crt
+CA_BUNDLE = /etc/ssl/certs/ca-bundle.crt
 VERSION = $(shell cat version.txt)
 
 BUILDER_IMAGE ?= golang:1.8.0-alpine
@@ -27,7 +27,7 @@ build:
 	CGO_ENABLED=0 go build -v -i --ldflags=--s
 
 ca-certificates.crt:
-	cp $(CA_BUNDLE) .
+	cp $(CA_BUNDLE) $@
 
 build-release: ca-certificates.crt
 	docker run --rm -v $(PWD)/..:/go/src/github.com/cesanta/docker_auth \

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -24,7 +24,13 @@ server:  # Server settings.
   # Use LetsEncrypt (https://letsencrypt.org/) to automatically obtain and maintain a certificate.
   # Note that this only applies to server TLS certificate, this certificate will not be used for tokens
   letsencrypt:
-    # Email is required. It will be used to register with LetsEncrypt.
+    # registryjson lets you point docker_auth at the letsencrypt.json file used by the registry
+    # so you can run both registry and docker_auth on the same machine without needing to jump
+    # through hoops to proxy port 443 to talk to letsencrypt.org, the file is watched for 
+    # modifications and reloaded so it should stay completely up-to-date with no additional work.
+    # Note: the "host:" setting below is required if you use registryjson so we can find the keys
+    registryjson: /path/to/letsencrypt.json
+    # Email is required unless using registryjson. It will be used to register with LetsEncrypt.
     email: webmaster@example.org
     # Cache directory, where certificates issued by LE will be stored. Must exist.
     # It is recommended to make it a volume mount so it persists across restarts.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -28,7 +28,10 @@ server:  # Server settings.
     # so you can run both registry and docker_auth on the same machine without needing to jump
     # through hoops to proxy port 443 to talk to letsencrypt.org, the file is watched for 
     # modifications and reloaded so it should stay completely up-to-date with no additional work.
-    # Note: the "host:" setting below is required if you use registryjson so we can find the keys
+    # Notes: 1. the "host:" setting below is required if you use registryjson so we can find the keys
+    #        2. you should run registry and hit it over port 443 so it creates the letsencrypt.json
+    #           before running it with docker_auth, you can just touch the file to create it so it
+    #           can be mounted, but you'll get a lot of log failures while things try to settle down
     registryjson: /path/to/letsencrypt.json
     # Email is required unless using registryjson. It will be used to register with LetsEncrypt.
     email: webmaster@example.org


### PR DESCRIPTION
As discussed here: https://github.com/cesanta/docker_auth/issues/210

The problem is you can't run docker_auth and registry on the same machine with letsencrypt without jumping through hoops because that service needs to talk to both services on port 443.  You can run a proxy like @techknowlogick mentions in that thread, or I wrote a simple bash script that can run on a timer and extract the key and certs from letsencrypt.json, but both of these are hacks (the proxy counts on the request URLs not overlapping, and the extractor runs on a sleep timer or else needs the busybox version of inotify). Clearly it'd be better to have this built into docker_auth, so I looked at the code and it was pretty simple to add, and I'd never played with Go and was curious, so I just did it.

The change is pretty simple, it adds a registryjson setting to the letsencrypt section, and if that's there, it adds the letsencrypt.json to the watched files (for when registry updates it) and extracts the key and cert directly.

The startup can be a little awkward if there's no letsencrypt.json, so I'd suggest getting your registry up and running and hit the /v2/ endpoint to get it to create the letsencrypt.json, then you can safely start up docker_auth.  I have a compose file that has them both in it with the right volume mappings and stuff, so I can add that if people are interested in an example.  You can get by with just touching letsencrypt.json to start up, but that makes docker_auth fail a bunch and it's not pretty in the logs, so better to just bootstrap ones. Also, be careful, I hit the letsencrypt rate limit while testing the startup cases!

Also, if you're going to test it by touching the letsencrypt.json file outside the contains while they're running, you need to be careful. For some reason the Go notify doesn't fire when you just touch the file, so you need to edit it and save, but you need to use an editor that overwrites the existing file (like emacs and I think nano), not deletes it and creates a new file (like vi) because then the inode is different and the mapping into the containers doesn't work (see this thread: https://github.com/moby/moby/issues/15793). But, the registry does the right thing and its changes get picked up, so that's just a testing weirdness.

Let me know if you've got questions, and I hope this can get integrated!
Chris

PS. The Makefile change snuck in there...the make target line is probably a good one to keep, but feel free to nuke the ca-bundle.crt change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/211)
<!-- Reviewable:end -->
