### PR TITLE
Set access_type=online for google auth

### DIFF
--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -179,6 +179,7 @@ func (ga *GoogleAuth) doGoogleAuthCreateToken(rw http.ResponseWriter, code strin
 			"client_secret": []string{ga.config.ClientSecret},
 			"redirect_uri":  []string{"postmessage"},
 			"grant_type":    []string{"authorization_code"},
+			"access_type":   []string{"online"},
 		})
 	if err != nil {
 		http.Error(rw, fmt.Sprintf("Error talking to Google auth backend: %s", err), http.StatusServiceUnavailable)


### PR DESCRIPTION
By default, the access_type is `offline`. There is no reason why offline access is required and it sounds insecure as why a single user has to allow offline access on his behalf. Moreover, it should involve a background refresh of access token which is not done in the code I guess.

We use access_type=online for a long time and it works perfectly. Only sometimes the user is re-asked to confirm Google access when the later decides to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/212)
<!-- Reviewable:end -->
