### PR TITLE
Add the `Labels` property to the `TokenDBValue` struct

### DIFF
--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -70,6 +70,7 @@ type TokenDBValue struct {
 	// DockerPassword is the temporary password we use to authenticate Docker users.
 	// Generated at the time of token creation, stored here as a BCrypt hash.
 	DockerPassword string `json:"docker_password,omitempty"`
+	Labels         Labels `json:"labels,omitempty"`
 }
 
 // NewTokenDB returns a new TokenDB structure


### PR DESCRIPTION
This patch extends the `TokenDBValue` struct in order to allow storing "labels" associated
with a user directly in the data structure, ie. without a need for secondary storage for lookup.

I'm aware that this changes a core entity, but we haven't found a simpler and non-invasive way of doing that, when working on the possibility of using Github teams as "labels" in the ACL configuration.

We think that it simplifies the workflow for anybody who would like to use a similar mechanism for authentication and authorization — after all, the amount of data to store in the token is very small, basically an array of strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/217)
<!-- Reviewable:end -->
