### PR TITLE
Small improvements to the build process

### DIFF
--- a/auth_server/Dockerfile
+++ b/auth_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM busybox
+FROM alpine
 ADD auth_server /docker_auth/
 COPY ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT ["/docker_auth/auth_server"]

--- a/auth_server/Dockerfile-builderimage
+++ b/auth_server/Dockerfile-builderimage
@@ -1,0 +1,4 @@
+#FROM busybox
+FROM golang:1.8.0-alpine
+RUN apk update && apk add git make py2-pip && \
+    pip install GitPython

--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -5,6 +5,7 @@ CA_BUNDLE = /etc/ssl/certs/ca-certificates.crt
 VERSION = $(shell cat version.txt)
 
 BUILDER_IMAGE ?= golang:1.8.0-alpine
+CUSTOM_BUILDER_IMAGE ?= docker-auth-build-image:latest
 
 .PHONY: %
 
@@ -29,10 +30,12 @@ build:
 ca-certificates.crt:
 	cp $(CA_BUNDLE) .
 
+custom-image:
+	docker build -t $(CUSTOM_BUILDER_IMAGE) -f ./Dockerfile-builderimage .
+
 build-release: ca-certificates.crt
 	docker run --rm -v $(PWD)/..:/go/src/github.com/cesanta/docker_auth \
-	  $(BUILDER_IMAGE) sh -x -c "\
-	    apk update && apk add git make py2-pip && pip install GitPython && \
+	  $(CUSTOM_BUILDER_IMAGE) sh -x -c "\
 	    cd /go/src/github.com/cesanta/docker_auth/auth_server && \
 	    go get -v -u github.com/kardianos/govendor && \
 	    umask 0 && govendor sync -v && \

--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables
 IMAGE ?= cesanta/docker_auth
 COMPRESS_BINARY ?= false
-CA_BUNDLE = /etc/ssl/certs/ca-certificates.crt
+CA_BUNDLE ?= /etc/ssl/certs/ca-certificates.crt
 VERSION = $(shell cat version.txt)
 
 BUILDER_IMAGE ?= golang:1.8.0-alpine
@@ -28,7 +28,7 @@ build:
 	CGO_ENABLED=0 go build -v -i --ldflags=--s
 
 ca-certificates.crt:
-	cp $(CA_BUNDLE) .
+	cp $(CA_BUNDLE) ./ca-certificates.crt
 
 custom-image:
 	docker build -t $(CUSTOM_BUILDER_IMAGE) -f ./Dockerfile-builderimage .

--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -33,12 +33,30 @@ ca-certificates.crt:
 custom-image:
 	docker build -t $(CUSTOM_BUILDER_IMAGE) -f ./Dockerfile-builderimage .
 
-build-release: ca-certificates.crt
+# Download vendor.json dependencies under vendor/ on the host
+pull-vendor-deps:
 	docker run --rm -v $(PWD)/..:/go/src/github.com/cesanta/docker_auth \
 	  $(CUSTOM_BUILDER_IMAGE) sh -x -c "\
 	    cd /go/src/github.com/cesanta/docker_auth/auth_server && \
 	    go get -v -u github.com/kardianos/govendor && \
 	    umask 0 && govendor sync -v && \
+	    go install -v github.com/cesanta/docker_auth/auth_server/vendor/github.com/jteeuwen/go-bindata/go-bindata && \
+	    umask 0 && govendor sync -v"
+
+# Build fast with docker; assumes you've already run `pull-vendor-deps`
+build-release-fast: ca-certificates.crt
+	docker run --rm -v $(PWD)/..:/go/src/github.com/cesanta/docker_auth \
+	  $(CUSTOM_BUILDER_IMAGE) sh -x -c "\
+	    cd /go/src/github.com/cesanta/docker_auth/auth_server && \
+	    go install -v github.com/cesanta/docker_auth/auth_server/vendor/github.com/jteeuwen/go-bindata/go-bindata && \
+	    make generate && \
+	    CGO_ENABLED=0 go build -v -i --ldflags=--s"
+	@echo === Built version $(VERSION) ===
+
+build-release: ca-certificates.crt pull-vendor-deps
+	docker run --rm -v $(PWD)/..:/go/src/github.com/cesanta/docker_auth \
+	  $(CUSTOM_BUILDER_IMAGE) sh -x -c "\
+	    cd /go/src/github.com/cesanta/docker_auth/auth_server && \
 	    go install -v github.com/cesanta/docker_auth/auth_server/vendor/github.com/jteeuwen/go-bindata/go-bindata && \
 	    make generate && \
 	    CGO_ENABLED=0 go build -v -i --ldflags=--s"


### PR DESCRIPTION
These couple of patches implement some small, but significant improvements for building the Go binary from source, most notably the addition of the `make build-release-fast` task, which cuts the time needed more than by half, by skipping the pulling of dependencies. On a MacBook Air 2013, it takes about 30 seconds, as opposed to almost 2 minutes for the `make build-release` task.

The `make custom-image` task needs to be run first, so a customized image with all the dependencies is being built.

It also allows to override the location of the certificate bundle, in order to use a different one, eg. the [Mozilla bundle](https://curl.haxx.se/ca/cacert.pem).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/218)
<!-- Reviewable:end -->
