### PR TITLE
Add a Redis-based token storage implementation

### DIFF
--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -79,7 +79,6 @@ type GitHubGCSStoreConfig struct {
 type GitHubRedisStoreConfig struct {
 	NodeOptions    *redis.Options        `yaml:"node_options,omitempty"`
 	ClusterOptions *redis.ClusterOptions `yaml:"cluster_options,omitempty"`
-	EncryptKey     string                `yaml:"encrypt_key,omitempty"`
 }
 
 type GitHubAuthRequest struct {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -76,7 +76,8 @@ type GitHubGCSStoreConfig struct {
 }
 
 type GitHubRedisStoreConfig struct {
-	Url string `yaml:"url,omitempty"`
+	Url        string `yaml:"url,omitempty"`
+	EncryptKey string `yaml:"encrypt_key,omitempty"`
 }
 
 type GitHubAuthRequest struct {
@@ -174,7 +175,7 @@ func NewGitHubAuth(c *GitHubAuthConfig) (*GitHubAuth, error) {
 		db, err = NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
 		dbName = "GCS: " + c.GCSTokenDB.Bucket
 	case c.RedisTokenDB != nil:
-		db, err = NewRedisTokenDB(c.RedisTokenDB.Url)
+		db, err = NewRedisTokenDB(c.RedisTokenDB.Url, c.RedisTokenDB.EncryptKey)
 		dbName = "Redis: " + c.RedisTokenDB.Url
 	default:
 		db, err = NewTokenDB(c.TokenDB)

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -77,8 +77,8 @@ type GitHubGCSStoreConfig struct {
 }
 
 type GitHubRedisStoreConfig struct {
-	NodeOptions    *redis.Options        `yaml:"node_options,omitempty"`
-	ClusterOptions *redis.ClusterOptions `yaml:"cluster_options,omitempty"`
+	ClientOptions  *redis.Options        `yaml:"redis_options,omitempty"`
+	ClusterOptions *redis.ClusterOptions `yaml:"redis_cluster_options,omitempty"`
 }
 
 type GitHubAuthRequest struct {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -76,8 +76,9 @@ type GitHubGCSStoreConfig struct {
 }
 
 type GitHubRedisStoreConfig struct {
-	Url        string `yaml:"url,omitempty"`
-	EncryptKey string `yaml:"encrypt_key,omitempty"`
+	Url        string   `yaml:"url,omitempty"`
+	Urls       []string `yaml:"urls,omitempty"`
+	EncryptKey string   `yaml:"encrypt_key,omitempty"`
 }
 
 type GitHubAuthRequest struct {
@@ -175,8 +176,13 @@ func NewGitHubAuth(c *GitHubAuthConfig) (*GitHubAuth, error) {
 		db, err = NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
 		dbName = "GCS: " + c.GCSTokenDB.Bucket
 	case c.RedisTokenDB != nil:
-		db, err = NewRedisTokenDB(c.RedisTokenDB.Url, c.RedisTokenDB.EncryptKey)
-		dbName = "Redis: " + c.RedisTokenDB.Url
+		if len(c.RedisTokenDB.Urls) > 0 {
+			db, err = NewRedisClusterTokenDB(c.RedisTokenDB.Urls, c.RedisTokenDB.EncryptKey)
+			dbName = "Redis Cluster: " + fmt.Sprintf("%v", c.RedisTokenDB.Urls)
+		} else {
+			db, err = NewRedisTokenDB(c.RedisTokenDB.Url, c.RedisTokenDB.EncryptKey)
+			dbName = "Redis: " + c.RedisTokenDB.Url
+		}
 	default:
 		db, err = NewTokenDB(c.TokenDB)
 	}

--- a/auth_server/authn/tokendb_redis.go
+++ b/auth_server/authn/tokendb_redis.go
@@ -17,15 +17,28 @@ import (
 	"github.com/go-redis/redis"
 )
 
-// NewRedisTokenDB returns a new TokenDB structure which uses Redis as backend.
+type RedisClient interface {
+	Get(key string) *redis.StringCmd
+	Set(key string, value interface{}, expiration time.Duration) *redis.StatusCmd
+	Del(keys ...string) *redis.IntCmd
+}
+
+// NewRedisTokenDB returns a new TokenDB structure which uses Redis as the storage backend.
 //
 func NewRedisTokenDB(url string, encrypt_key string) (TokenDB, error) {
 	client := redis.NewClient(&redis.Options{Addr: url})
 	return &redisTokenDB{client, encrypt_key}, nil
 }
 
+// NewRedisClusterTokenDB returns a new TokenDB structure which uses Redis Cluster as the storage backend.
+//
+func NewRedisClusterTokenDB(urls []string, encrypt_key string) (TokenDB, error) {
+	client := redis.NewClusterClient(&redis.ClusterOptions{Addrs: urls})
+	return &redisTokenDB{client, encrypt_key}, nil
+}
+
 type redisTokenDB struct {
-	client      *redis.Client
+	client      RedisClient
 	encrypt_key string
 }
 

--- a/auth_server/authn/tokendb_redis.go
+++ b/auth_server/authn/tokendb_redis.go
@@ -24,9 +24,12 @@ type RedisClient interface {
 func NewRedisTokenDB(options *GitHubRedisStoreConfig) (TokenDB, error) {
 	var client RedisClient
 	if options.ClusterOptions != nil {
+		if options.ClientOptions != nil {
+			glog.Infof("Both redis_token_db.configs and redis_token_db.cluster_configs have been set. Only the latter will be used")
+		}
 		client = redis.NewClusterClient(options.ClusterOptions)
 	} else {
-		client = redis.NewClient(options.NodeOptions)
+		client = redis.NewClient(options.ClientOptions)
 	}
 
 	return &redisTokenDB{client}, nil

--- a/auth_server/authn/tokendb_redis.go
+++ b/auth_server/authn/tokendb_redis.go
@@ -1,0 +1,112 @@
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/cesanta/glog"
+	"github.com/dchest/uniuri"
+	"github.com/go-redis/redis"
+)
+
+// NewRedisTokenDB returns a new TokenDB structure which uses Redis as backend.
+//
+func NewRedisTokenDB(url string) (TokenDB, error) {
+	client := redis.NewClient(&redis.Options{Addr: url})
+	return &redisTokenDB{client}, nil
+}
+
+type redisTokenDB struct {
+	client *redis.Client
+}
+
+func (db *redisTokenDB) GetValue(user string) (*TokenDBValue, error) {
+	// Short-circuit calling Redis when the user is anonymous
+	if user == "" {
+		return nil, nil
+	}
+
+	key := string(getDBKey(user))
+
+	result, err := db.client.Get(key).Result()
+	if err == redis.Nil {
+		glog.V(2).Infof("Key <%s> doesn't exist\n", key)
+		return nil, nil
+	} else if err != nil {
+		glog.Errorf("Error getting Redis key <%s>: %s\n", key, err)
+		return nil, fmt.Errorf("Error getting key <%s>: %s", key, err)
+	}
+
+	var dbv TokenDBValue
+	err = json.Unmarshal([]byte(result), &dbv)
+	if err != nil {
+		glog.Errorf("Error parsing value for user <%q> (%q): %s", user, string(result), err)
+		return nil, fmt.Errorf("Error parsing value: %v", err)
+	}
+	glog.V(2).Infof("Redis: GET %s : %v\n", key, result)
+	return &dbv, nil
+}
+
+func (db *redisTokenDB) StoreToken(user string, v *TokenDBValue, updatePassword bool) (dp string, err error) {
+	if updatePassword {
+		dp = uniuri.New()
+		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), bcrypt.DefaultCost)
+		v.DockerPassword = string(dph)
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	key := string(getDBKey(user))
+
+	err = db.client.Set(key, data, 0).Err()
+	if err != nil {
+		glog.Errorf("Failed to set token data for user <%s>: %s", user, err)
+		return "", fmt.Errorf("Failed to set token data for user <%s>: %s", user, err)
+	}
+
+	glog.V(2).Infof("Server tokens for <%s>: %s", user, string(data))
+	return
+}
+
+func (db *redisTokenDB) ValidateToken(user string, password PasswordString) error {
+	dbv, err := db.GetValue(user)
+
+	if err != nil {
+		return err
+	}
+
+	if dbv == nil {
+		return NoMatch
+	}
+
+	if bcrypt.CompareHashAndPassword([]byte(dbv.DockerPassword), []byte(password)) != nil {
+		return WrongPass
+	}
+
+	if time.Now().After(dbv.ValidUntil) {
+		return ExpiredToken
+	}
+
+	return nil
+}
+
+func (db *redisTokenDB) DeleteToken(user string) error {
+	glog.Infof("Deleting token for user <%s>", user)
+
+	key := string(getDBKey(user))
+	err := db.client.Del(key).Err()
+	if err != nil {
+		return fmt.Errorf("Failed to delete token for user <%s>: %s", user, err)
+	}
+	return nil
+}
+
+func (db *redisTokenDB) Close() error {
+	return nil
+}

--- a/auth_server/go.mod
+++ b/auth_server/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/facebookgo/httpdown v0.0.0-20180706035922-5979d39b15c2
 	github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4 // indirect
 	github.com/go-ldap/ldap v3.0.3+incompatible
+	github.com/go-redis/redis v6.15.7+incompatible
 	github.com/gorilla/mux v1.7.3 // indirect
 	github.com/schwarmco/go-cartesian-product v0.0.0-20180515110546-d5ee747a6dc9
 	github.com/sirupsen/logrus v1.4.2 // indirect

--- a/auth_server/go.sum
+++ b/auth_server/go.sum
@@ -30,6 +30,8 @@ github.com/facebookgo/stats v0.0.0-20151006221625-1b76add642e4/go.mod h1:vsJz7uE
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-ldap/ldap v3.0.3+incompatible h1:HTeSZO8hWMS1Rgb2Ziku6b8a7qRIZZMHjsvuZyatzwk=
 github.com/go-ldap/ldap v3.0.3+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
+github.com/go-redis/redis v6.15.7+incompatible h1:3skhDh95XQMpnqeqNftPkQD9jL9e5e36z/1SUm6dy1U=
+github.com/go-redis/redis v6.15.7+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -196,8 +196,8 @@ func validate(c *Config) error {
 			return errors.New("github_auth.{client_id,client_secret,gcs_token_db{bucket,client_secret_file}} are required")
 		}
 
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.NodeOptions.Addr == "" && len(ghac.RedisTokenDB.ClusterOptions.Addrs) < 1) {
-			return errors.New("github_auth.{client_id,client_secret,redis_token_db.{node_options,cluster_options}} are required")
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.ClientOptions == nil && ghac.RedisTokenDB.ClusterOptions == nil) {
+			return errors.New("github_auth.{client_id,client_secret,redis_token_db.{redis_options,redis_cluster_options}} are required")
 		}
 
 		if ghac.HTTPTimeout <= 0 {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -196,8 +196,8 @@ func validate(c *Config) error {
 			return errors.New("github_auth.{client_id,client_secret,gcs_token_db{bucket,client_secret_file}} are required")
 		}
 
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.Url == "" && len(ghac.RedisTokenDB.Urls) < 1) {
-			return errors.New("github_auth.{client_id,client_secret,redis_token_db{url(s)}} are required")
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.NodeOptions.Addr == "" && len(ghac.RedisTokenDB.ClusterOptions.Addrs) < 1) {
+			return errors.New("github_auth.{client_id,client_secret,redis_token_db.{node_options,cluster_options}} are required")
 		}
 
 		if ghac.RedisTokenDB != nil && ghac.RedisTokenDB.EncryptKey != "" && len(ghac.RedisTokenDB.EncryptKey) != 32 {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -200,6 +200,10 @@ func validate(c *Config) error {
 			return errors.New("github_auth.{client_id,client_secret,redis_token_db{url}} are required")
 		}
 
+		if ghac.RedisTokenDB != nil && ghac.RedisTokenDB.EncryptKey != "" && len(ghac.RedisTokenDB.EncryptKey) != 32 {
+			return errors.New("github_auth.{redis_token_db{encrypt_key}} must be exactly 32 bytes long")
+		}
+
 		if ghac.HTTPTimeout <= 0 {
 			ghac.HTTPTimeout = time.Duration(10 * time.Second)
 		}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -200,10 +200,6 @@ func validate(c *Config) error {
 			return errors.New("github_auth.{client_id,client_secret,redis_token_db.{node_options,cluster_options}} are required")
 		}
 
-		if ghac.RedisTokenDB != nil && ghac.RedisTokenDB.EncryptKey != "" && len(ghac.RedisTokenDB.EncryptKey) != 32 {
-			return errors.New("github_auth.{redis_token_db{encrypt_key}} must be exactly 32 bytes long")
-		}
-
 		if ghac.HTTPTimeout <= 0 {
 			ghac.HTTPTimeout = time.Duration(10 * time.Second)
 		}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -188,13 +188,18 @@ func validate(c *Config) error {
 			}
 			ghac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.TokenDB == "" && ghac.GCSTokenDB == nil) {
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.TokenDB == "" && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
 			return errors.New("github_auth.{client_id,client_secret,token_db} are required")
 		}
 
 		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.GCSTokenDB != nil && (ghac.GCSTokenDB.Bucket == "" || ghac.GCSTokenDB.ClientSecretFile == "")) {
 			return errors.New("github_auth.{client_id,client_secret,gcs_token_db{bucket,client_secret_file}} are required")
 		}
+
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.Url == "") {
+			return errors.New("github_auth.{client_id,client_secret,redis_token_db{url}} are required")
+		}
+
 		if ghac.HTTPTimeout <= 0 {
 			ghac.HTTPTimeout = time.Duration(10 * time.Second)
 		}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -196,8 +196,8 @@ func validate(c *Config) error {
 			return errors.New("github_auth.{client_id,client_secret,gcs_token_db{bucket,client_secret_file}} are required")
 		}
 
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.Url == "") {
-			return errors.New("github_auth.{client_id,client_secret,redis_token_db{url}} are required")
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.RedisTokenDB != nil && ghac.RedisTokenDB.Url == "" && len(ghac.RedisTokenDB.Urls) < 1) {
+			return errors.New("github_auth.{client_id,client_secret,redis_token_db{url(s)}} are required")
 		}
 
 		if ghac.RedisTokenDB != nil && ghac.RedisTokenDB.EncryptKey != "" && len(ghac.RedisTokenDB.EncryptKey) != 32 {

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -139,10 +139,12 @@ github_auth:
     client_secret_file: "/path/to/client_secret.json"
   # or Redis,
   redis_token_db:
-    # with a single instance,
-    url: localhost:6379
-    # or in the cluster mode.
-    urls: ["localhost:7000"]
+    node_options:
+        # with a single instance,
+        addr: localhost:6379
+    cluster_options:
+        # or in the cluster mode.
+        addrs: ["localhost:7000"]
     # Optionally set an encryption key for Redis (must be exactly 32 bytes).
     encrypt_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   # How long to wait when talking to GitHub servers. Optional.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -145,8 +145,6 @@ github_auth:
     cluster_options:
         # or in the cluster mode.
         addrs: ["localhost:7000"]
-    # Optionally set an encryption key for Redis (must be exactly 32 bytes).
-    encrypt_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   # How long to wait when talking to GitHub servers. Optional.
   http_timeout: "10s"
   # How long to wait before revalidating the GitHub token. Optional.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -133,14 +133,17 @@ github_auth:
   client_secret_file: "/path/to/client_secret.txt"
   # Either token_db file for storing of server tokens.
   token_db: "/somewhere/to/put/github_tokens.ldb"
-  # or google cloud storage for storing of the sensitive information.
+  # or google cloud storage for storing of the sensitive information,
   gcs_token_db:
     bucket: "tokenBucket"
     client_secret_file: "/path/to/client_secret.json"
-  # or Redis.
+  # or Redis,
   redis_token_db:
+    # with a single instance,
     url: localhost:6379
-    # Optionally set an encryption key for Redis (must be exactly 32 bytes)
+    # or in the cluster mode.
+    urls: ["localhost:7000"]
+    # Optionally set an encryption key for Redis (must be exactly 32 bytes).
     encrypt_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   # How long to wait when talking to GitHub servers. Optional.
   http_timeout: "10s"

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -139,10 +139,10 @@ github_auth:
     client_secret_file: "/path/to/client_secret.json"
   # or Redis,
   redis_token_db:
-    node_options:
+    redis_options:
         # with a single instance,
         addr: localhost:6379
-    cluster_options:
+    redis_cluster_options:
         # or in the cluster mode.
         addrs: ["localhost:7000"]
   # How long to wait when talking to GitHub servers. Optional.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -137,6 +137,9 @@ github_auth:
   gcs_token_db:
     bucket: "tokenBucket"
     client_secret_file: "/path/to/client_secret.json"
+  # or Redis.
+  redis_token_db:
+    url: localhost:6379
   # How long to wait when talking to GitHub servers. Optional.
   http_timeout: "10s"
   # How long to wait before revalidating the GitHub token. Optional.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -140,6 +140,8 @@ github_auth:
   # or Redis.
   redis_token_db:
     url: localhost:6379
+    # Optionally set an encryption key for Redis (must be exactly 32 bytes)
+    encrypt_key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   # How long to wait when talking to GitHub servers. Optional.
   http_timeout: "10s"
   # How long to wait before revalidating the GitHub token. Optional.


### PR DESCRIPTION
This pull request adds a new type, `redisTokenDB`, which implements a token storage based on [_Redis_](https://redis.io).

The primary motivation is to allow the authentication server to run in a distributed environments, with multiple instances of the server proxied by a load balancer. The default file-based implementation is insufficient in such a scenario, because each server would have its own database of tokens, and the Google Cloud Storage-based implementation is prohibitive when the service would run eg. on AWS, due to latency issues.

The Redis-based implementation can work with a single Redis instance or a Redis Cluster — the corresponding client is selected based on the YAML configuration, where the user provides either a single `url` value as a string, or one or more `urls` as an array of strings (see the updated `reference.yml` file).

The Redis-based implementation adds two additional functions, `Encrypt()` and `Decrypt()`, which allow to encrypt the values before storing them, using the AES support in Go standard library, when the `encrypt_key` is set in the YAML configuration (again, see the updated `reference.yml` file).

The pull request also adds support for using the Redis-bases token storage in the Github authentication mechanism (`authn/github_auth.go`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/220)
<!-- Reviewable:end -->
