### PR TITLE
Improve the `docker login` instructions for Github authentication

### DIFF
--- a/auth_server/authn/bindata.go
+++ b/auth_server/authn/bindata.go
@@ -172,6 +172,12 @@ var _dataGithub_auth_resultTmpl = []byte(`<!doctype html>
       border-radius: 0.5em;
       text-shadow: 0px 1px 0px #fff;
     }
+    .command span {
+      user-select: none;
+      -moz-user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+    }
   </style>
 </head>
 <body>
@@ -180,7 +186,7 @@ var _dataGithub_auth_resultTmpl = []byte(`<!doctype html>
     Use the following username and password to login into the registry:
   </p>
   <hr>
-  <pre class="command">$ docker login -u {{.Username}} -p {{.Password}} YOUR_REGISTRY_FQDN</pre>
+  <pre class="command"><span>$ </span>docker login -u {{.Username}} -p {{.Password}} {{if .RegistryUrl}}{{.RegistryUrl}}{{else}}docker.example.com{{end}}</pre>
 </body>
 </html>
 `)
@@ -195,7 +201,7 @@ func dataGithub_auth_resultTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "data/github_auth_result.tmpl", size: 1094, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "data/github_auth_result.tmpl", size: 1300, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/auth_server/authn/data/github_auth_result.tmpl
+++ b/auth_server/authn/data/github_auth_result.tmpl
@@ -32,6 +32,12 @@
       border-radius: 0.5em;
       text-shadow: 0px 1px 0px #fff;
     }
+    .command span {
+      user-select: none;
+      -moz-user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+    }
   </style>
 </head>
 <body>
@@ -40,6 +46,6 @@
     Use the following username and password to login into the registry:
   </p>
   <hr>
-  <pre class="command">$ docker login -u {{.Username}} -p {{.Password}} YOUR_REGISTRY_FQDN</pre>
+  <pre class="command"><span>$ </span>docker login -u {{.Username}} -p {{.Password}} {{if .RegistryUrl}}{{.RegistryUrl}}{{else}}docker.example.com{{end}}</pre>
 </body>
 </html>

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -64,6 +64,7 @@ type GitHubAuthConfig struct {
 	RevalidateAfter  time.Duration         `yaml:"revalidate_after,omitempty"`
 	GithubWebUri     string                `yaml:"github_web_uri,omitempty"`
 	GithubApiUri     string                `yaml:"github_api_uri,omitempty"`
+	RegistryUrl      string                `yaml:"registry_url,omitempty"`
 }
 
 type GitHubGCSStoreConfig struct {
@@ -193,10 +194,11 @@ func (gha *GitHubAuth) doGitHubAuthPage(rw http.ResponseWriter, req *http.Reques
 
 func (gha *GitHubAuth) doGitHubAuthResultPage(rw http.ResponseWriter, username string, password string) {
 	if err := gha.tmplResult.Execute(rw, struct {
-		Organization, Username, Password string
+		Organization, Username, Password, RegistryUrl string
 	}{Organization: gha.config.Organization,
-		Username: username,
-		Password: password}); err != nil {
+		Username:    username,
+		Password:    password,
+		RegistryUrl: gha.config.RegistryUrl}); err != nil {
 		http.Error(rw, fmt.Sprintf("Template error: %s", err), http.StatusInternalServerError)
 	}
 }

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -117,6 +117,8 @@ github_auth:
   # The Github API URI in case you are using Github Enterprise.
   # Includes the protocol, without trailing slash. - defaults to: https://api.github.com
   github_api_uri: "https://github.acme.com/api/v3" 
+  # Set an URL to display in the `docker login` command when succesfully authenticated. Optional.
+  registry_url: localhost:5000
 
 # LDAP authentication.
 # Authentication is performed by first binding to the server, looking up the user entry


### PR DESCRIPTION
*** NOT READY TO MERGE ***

This pull request depends on https://github.com/cesanta/docker_auth/pull/219 and significantly improves the usability of the Github authentication workflow, by displaying a complete `docker login` command on the result page (ie. including the repository hostname), when a `registry_url` value is set in the configuration YAML.

![docker-login-full](https://user-images.githubusercontent.com/4790/36259130-752b6e56-125d-11e8-913c-176e798a9747.png)

The only significant commit is 9ba3328, and the branch has to be rebased before merging it, since the three other commits are redundant — this was the only way we could keep separate branches for the "github teams" and "redis tokendb" features isolated in our repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/221)
<!-- Reviewable:end -->
