### PR TITLE
drop old hardcoded configs around TLS 1.x

### DIFF
--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -50,19 +50,7 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 	}
 
 	tlsConfig := &tls.Config{
-		MinVersion:               tls.VersionTLS10,
 		PreferServerCipherSuites: true,
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		},
-		NextProtos: []string{"http/1.1"},
 	}
 	if c.Server.CertFile != "" || c.Server.KeyFile != "" {
 		// Check for partial configuration.


### PR DESCRIPTION
Modern Go versions (1.9 and 1.10) as of this commit are much better
about cipher suite selection and the ssl/tls protocols used. In fact,
SSLv3 needs to be explicitly enabled now.

Fixes: https://github.com/cesanta/docker_auth/issues/231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/232)
<!-- Reviewable:end -->
