### PR TITLE
 [Discussion] Add common module for library usage

### DIFF
--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -24,7 +24,7 @@ generate:
 	  github.com/cesanta/docker_auth/auth_server/server/...
 
 build:
-	CGO_ENABLED=0 go build -v --ldflags=--s
+	CGO_ENABLED=0 go build --ldflags=--s
 
 ca-certificates.crt:
 	cp $(CA_BUNDLE) .

--- a/auth_server/authn/ext_auth.go
+++ b/auth_server/authn/ext_auth.go
@@ -24,6 +24,8 @@ import (
 	"syscall"
 
 	"github.com/cesanta/glog"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type ExtAuthConfig struct {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -29,6 +29,8 @@ import (
 	"time"
 
 	"github.com/cesanta/glog"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type GitHubTeamCollection []GitHubTeam

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	"github.com/cesanta/glog"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type GoogleAuthConfig struct {

--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/go-ldap/ldap"
 	"github.com/cesanta/glog"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type LDAPAuthConfig struct {

--- a/auth_server/authn/mongo_auth.go
+++ b/auth_server/authn/mongo_auth.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type MongoAuthConfig struct {

--- a/auth_server/authn/static_auth.go
+++ b/auth_server/authn/static_auth.go
@@ -19,6 +19,8 @@ package authn
 import (
 	"encoding/json"
 	"golang.org/x/crypto/bcrypt"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type Requirements struct {

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -27,6 +27,8 @@ import (
 	"github.com/cesanta/glog"
 	"github.com/dchest/uniuri"
 	"github.com/syndtr/goleveldb/leveldb"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 const (

--- a/auth_server/authn/tokendb_gcs.go
+++ b/auth_server/authn/tokendb_gcs.go
@@ -26,6 +26,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/net/context"
 	"google.golang.org/api/option"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 // NewGCSTokenDB return a new TokenDB structure which uses Google Cloud Storage as backend. The

--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -10,9 +10,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cesanta/docker_auth/auth_server/authn"
 	"github.com/cesanta/glog"
 	"github.com/schwarmco/go-cartesian-product"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type ACL []ACLEntry
@@ -204,7 +205,7 @@ func matchIP(ipp *string, ip net.IP) bool {
 	return ipnet.Contains(ip)
 }
 
-func matchLabels(ml map[string]string, rl authn.Labels, vars []string) bool {
+func matchLabels(ml map[string]string, rl Labels, vars []string) bool {
 	for label, pattern := range ml {
 		labelValues := rl[label]
 		matched := false

--- a/auth_server/authz/acl_mongo.go
+++ b/auth_server/authz/acl_mongo.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"sync"
 	"time"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type MongoACL []MongoACLEntry

--- a/auth_server/authz/ext_authz.go
+++ b/auth_server/authz/ext_authz.go
@@ -24,6 +24,8 @@ import (
 	"syscall"
 
 	"github.com/cesanta/glog"
+
+	. "github.com/cesanta/docker_auth/auth_server/common"
 )
 
 type ExtAuthzConfig struct {

--- a/auth_server/common/authn.go
+++ b/auth_server/common/authn.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package authn
+package common
 
 import "errors"
 

--- a/auth_server/common/authz.go
+++ b/auth_server/common/authz.go
@@ -1,12 +1,9 @@
-package authz
+package common
 
 import (
-	"errors"
 	"fmt"
 	"net"
 	"strings"
-
-	"github.com/cesanta/docker_auth/auth_server/authn"
 )
 
 // Authorizer interface performs authorization of the request.
@@ -32,8 +29,6 @@ type Authorizer interface {
 	Name() string
 }
 
-var NoMatch = errors.New("did not match any rule")
-
 type AuthRequestInfo struct {
 	Account string
 	Type    string
@@ -41,7 +36,7 @@ type AuthRequestInfo struct {
 	Service string
 	IP      net.IP
 	Actions []string
-	Labels  authn.Labels
+	Labels  Labels
 }
 
 func (ai AuthRequestInfo) String() string {

--- a/auth_server/common/authz.go
+++ b/auth_server/common/authz.go
@@ -1,3 +1,19 @@
+/*
+   Copyright 2015 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package common
 
 import (

--- a/auth_server/common/config.go
+++ b/auth_server/common/config.go
@@ -19,18 +19,18 @@ package common
 import (
 	"crypto/tls"
 	"crypto/x509"
-   	"net"
+	"net"
 
 	"github.com/docker/libtrust"
 )
 
 type ServerConfig struct {
-	ListenAddress string            `yaml:"addr,omitempty"`
-	PathPrefix    string            `yaml:"path_prefix,omitempty"`
-	RealIPHeader  string            `yaml:"real_ip_header,omitempty"`
-	RealIPPos     int               `yaml:"real_ip_pos,omitempty"`
-	CertFile      string            `yaml:"certificate,omitempty"`
-	KeyFile       string            `yaml:"key,omitempty"`
+	ListenAddress string `yaml:"addr,omitempty"`
+	PathPrefix    string `yaml:"path_prefix,omitempty"`
+	RealIPHeader  string `yaml:"real_ip_header,omitempty"`
+	RealIPPos     int    `yaml:"real_ip_pos,omitempty"`
+	CertFile      string `yaml:"certificate,omitempty"`
+	KeyFile       string `yaml:"key,omitempty"`
 
 	PublicKey  libtrust.PublicKey
 	PrivateKey libtrust.PrivateKey

--- a/auth_server/common/config.go
+++ b/auth_server/common/config.go
@@ -1,0 +1,87 @@
+/*
+   Copyright 2015 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package common
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+   	"net"
+
+	"github.com/docker/libtrust"
+)
+
+type ServerConfig struct {
+	ListenAddress string            `yaml:"addr,omitempty"`
+	PathPrefix    string            `yaml:"path_prefix,omitempty"`
+	RealIPHeader  string            `yaml:"real_ip_header,omitempty"`
+	RealIPPos     int               `yaml:"real_ip_pos,omitempty"`
+	CertFile      string            `yaml:"certificate,omitempty"`
+	KeyFile       string            `yaml:"key,omitempty"`
+
+	PublicKey  libtrust.PublicKey
+	PrivateKey libtrust.PrivateKey
+}
+
+type TokenConfig struct {
+	Issuer     string `yaml:"issuer,omitempty"`
+	CertFile   string `yaml:"certificate,omitempty"`
+	KeyFile    string `yaml:"key,omitempty"`
+	Expiration int64  `yaml:"expiration,omitempty"`
+
+	PublicKey  libtrust.PublicKey
+	PrivateKey libtrust.PrivateKey
+}
+
+type AuthRequest struct {
+	RemoteConnAddr string
+	RemoteAddr     string
+	RemoteIP       net.IP
+	User           string
+	Password       PasswordString
+	Account        string
+	Service        string
+	Scopes         []AuthScope
+	Labels         Labels
+}
+
+type AuthScope struct {
+	Type    string
+	Name    string
+	Actions []string
+}
+
+type AuthzResult struct {
+	Scope            AuthScope
+	AutorizedActions []string
+}
+
+func LoadCertAndKey(certFile, keyFile string) (pk libtrust.PublicKey, prk libtrust.PrivateKey, err error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return
+	}
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return
+	}
+	pk, err = libtrust.FromCryptoPublicKey(x509Cert.PublicKey)
+	if err != nil {
+		return
+	}
+	prk, err = libtrust.FromCryptoPrivateKey(cert.PrivateKey)
+	return
+}

--- a/auth_server/common/simple_server.go
+++ b/auth_server/common/simple_server.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/cesanta/glog"
 	"github.com/docker/distribution/registry/auth/token"
-
 )
 
 var (

--- a/auth_server/common/simple_server.go
+++ b/auth_server/common/simple_server.go
@@ -1,0 +1,326 @@
+/*
+   Copyright 2015 Cesanta Software Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cesanta/glog"
+	"github.com/docker/distribution/registry/auth/token"
+
+)
+
+var (
+	hostPortRegex = regexp.MustCompile(`\[?(.+?)\]?:\d+$`)
+)
+
+// SimpleServer rigs the Authenticator and Authorizer interfaces into a cohesive whole, but without provider-specific logic.
+// Unless you are using as a library, you probably want the AuthServer in the server package.
+type SimpleServer struct {
+	Server         ServerConfig
+	Token          TokenConfig
+	Authenticators []Authenticator
+	Authorizers    []Authorizer
+}
+
+func (ar AuthRequest) String() string {
+	return fmt.Sprintf("{%s:%s@%s %s}", ar.User, ar.Password, ar.RemoteAddr, ar.Scopes)
+}
+
+func parseRemoteAddr(ra string) net.IP {
+	hp := hostPortRegex.FindStringSubmatch(ra)
+	if hp != nil {
+		ra = string(hp[1])
+	}
+	res := net.ParseIP(ra)
+	return res
+}
+
+func (as *SimpleServer) ParseRequest(req *http.Request) (*AuthRequest, error) {
+	ar := &AuthRequest{RemoteConnAddr: req.RemoteAddr, RemoteAddr: req.RemoteAddr}
+	if as.Server.RealIPHeader != "" {
+		hv := req.Header.Get(as.Server.RealIPHeader)
+		ips := strings.Split(hv, ",")
+
+		realIPPos := as.Server.RealIPPos
+		if realIPPos < 0 {
+			realIPPos = len(ips) + realIPPos
+			if realIPPos < 0 {
+				realIPPos = 0
+			}
+		}
+
+		ar.RemoteAddr = strings.TrimSpace(ips[realIPPos])
+		glog.V(3).Infof("Conn ip %s, %s: %s, addr: %s", ar.RemoteAddr, as.Server.RealIPHeader, hv, ar.RemoteAddr)
+		if ar.RemoteAddr == "" {
+			return nil, fmt.Errorf("client address not provided")
+		}
+	}
+	ar.RemoteIP = parseRemoteAddr(ar.RemoteAddr)
+	if ar.RemoteIP == nil {
+		return nil, fmt.Errorf("unable to parse remote addr %s", ar.RemoteAddr)
+	}
+	user, password, haveBasicAuth := req.BasicAuth()
+	if haveBasicAuth {
+		ar.User = user
+		ar.Password = PasswordString(password)
+	}
+	ar.Account = req.FormValue("account")
+	if ar.Account == "" {
+		ar.Account = ar.User
+	} else if haveBasicAuth && ar.Account != ar.User {
+		return nil, fmt.Errorf("user and account are not the same (%q vs %q)", ar.User, ar.Account)
+	}
+	ar.Service = req.FormValue("service")
+	if err := req.ParseForm(); err != nil {
+		return nil, fmt.Errorf("invalid form value")
+	}
+	// https://github.com/docker/distribution/blob/1b9ab303a477ded9bdd3fc97e9119fa8f9e58fca/docs/spec/auth/scope.md#resource-scope-grammar
+	if req.FormValue("scope") != "" {
+		for _, scopeStr := range req.Form["scope"] {
+			parts := strings.Split(scopeStr, ":")
+			var scope AuthScope
+			switch len(parts) {
+			case 3:
+				scope = AuthScope{
+					Type:    parts[0],
+					Name:    parts[1],
+					Actions: strings.Split(parts[2], ","),
+				}
+			case 4:
+				scope = AuthScope{
+					Type:    parts[0],
+					Name:    parts[1] + ":" + parts[2],
+					Actions: strings.Split(parts[3], ","),
+				}
+			default:
+				return nil, fmt.Errorf("invalid scope: %q", scopeStr)
+			}
+			sort.Strings(scope.Actions)
+			ar.Scopes = append(ar.Scopes, scope)
+		}
+	}
+	return ar, nil
+}
+
+func (as *SimpleServer) Authenticate(ar *AuthRequest) (bool, Labels, error) {
+	for i, a := range as.Authenticators {
+		result, labels, err := a.Authenticate(ar.Account, ar.Password)
+		glog.V(2).Infof("Authn %s %s -> %t, %+v, %v", a.Name(), ar.Account, result, labels, err)
+		if err != nil {
+			if err == NoMatch {
+				continue
+			} else if err == WrongPass {
+				glog.Warningf("Failed authentication with %s: %s", err, ar.Account)
+				return false, nil, nil
+			}
+			err = fmt.Errorf("authn #%d returned error: %s", i+1, err)
+			glog.Errorf("%s: %s", ar, err)
+			return false, nil, err
+		}
+		return result, labels, nil
+	}
+	// Deny by default.
+	glog.Warningf("%s did not match any authn rule", ar)
+	return false, nil, nil
+}
+
+func (as *SimpleServer) authorizeScope(ai *AuthRequestInfo) ([]string, error) {
+	for i, a := range as.Authorizers {
+		result, err := a.Authorize(ai)
+		glog.V(2).Infof("Authz %s %s -> %s, %s", a.Name(), *ai, result, err)
+		if err != nil {
+			if err == NoMatch {
+				continue
+			}
+			err = fmt.Errorf("authz #%d returned error: %s", i+1, err)
+			glog.Errorf("%s: %s", *ai, err)
+			return nil, err
+		}
+		return result, nil
+	}
+	// Deny by default.
+	glog.Warningf("%s did not match any authz rule", *ai)
+	return nil, nil
+}
+
+func (as *SimpleServer) Authorize(ar *AuthRequest) ([]AuthzResult, error) {
+	ares := []AuthzResult{}
+	for _, scope := range ar.Scopes {
+		ai := &AuthRequestInfo{
+			Account: ar.Account,
+			Type:    scope.Type,
+			Name:    scope.Name,
+			Service: ar.Service,
+			IP:      ar.RemoteIP,
+			Actions: scope.Actions,
+			Labels:  ar.Labels,
+		}
+		actions, err := as.authorizeScope(ai)
+		if err != nil {
+			return nil, err
+		}
+		ares = append(ares, AuthzResult{Scope: scope, AutorizedActions: actions})
+	}
+	return ares, nil
+}
+
+// https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md#example
+func (as *SimpleServer) CreateToken(ar *AuthRequest, ares []AuthzResult) (string, error) {
+	now := time.Now().Unix()
+	tc := &as.Token
+
+	// Sign something dummy to find out which algorithm is used.
+	_, sigAlg, err := tc.PrivateKey.Sign(strings.NewReader("dummy"), 0)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign: %s", err)
+	}
+	header := token.Header{
+		Type:       "JWT",
+		SigningAlg: sigAlg,
+		KeyID:      tc.PublicKey.KeyID(),
+	}
+	headerJSON, err := json.Marshal(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal header: %s", err)
+	}
+
+	claims := token.ClaimSet{
+		Issuer:     tc.Issuer,
+		Subject:    ar.Account,
+		Audience:   ar.Service,
+		NotBefore:  now - 10,
+		IssuedAt:   now,
+		Expiration: now + tc.Expiration,
+		JWTID:      fmt.Sprintf("%d", rand.Int63()),
+		Access:     []*token.ResourceActions{},
+	}
+	for _, a := range ares {
+		ra := &token.ResourceActions{
+			Type:    a.Scope.Type,
+			Name:    a.Scope.Name,
+			Actions: a.AutorizedActions,
+		}
+		if ra.Actions == nil {
+			ra.Actions = []string{}
+		}
+		sort.Strings(ra.Actions)
+		claims.Access = append(claims.Access, ra)
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal claims: %s", err)
+	}
+
+	payload := fmt.Sprintf("%s%s%s", JoseBase64UrlEncode(headerJSON), token.TokenSeparator, JoseBase64UrlEncode(claimsJSON))
+
+	sig, sigAlg2, err := tc.PrivateKey.Sign(strings.NewReader(payload), 0)
+	if err != nil || sigAlg2 != sigAlg {
+		return "", fmt.Errorf("failed to sign token: %s", err)
+	}
+	glog.Infof("New token for %s %+v: %s", *ar, ar.Labels, claimsJSON)
+	return fmt.Sprintf("%s%s%s", payload, token.TokenSeparator, JoseBase64UrlEncode(sig)), nil
+}
+
+func (as *SimpleServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	glog.V(3).Infof("Request: %+v", req)
+	path_prefix := as.Server.PathPrefix
+	switch {
+	case req.URL.Path == path_prefix+"/":
+		as.DoIndex(rw, req)
+	case req.URL.Path == path_prefix+"/auth":
+		as.DoAuth(rw, req)
+	default:
+		http.Error(rw, "Not found", http.StatusNotFound)
+		return
+	}
+}
+
+// https://developers.google.com/identity/sign-in/web/server-side-flow
+func (as *SimpleServer) DoIndex(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(rw, "<h1>%s</h1>\n", as.Token.Issuer)
+}
+
+func (as *SimpleServer) DoAuth(rw http.ResponseWriter, req *http.Request) {
+	ar, err := as.ParseRequest(req)
+	ares := []AuthzResult{}
+	if err != nil {
+		glog.Warningf("Bad request: %s", err)
+		http.Error(rw, fmt.Sprintf("Bad request: %s", err), http.StatusBadRequest)
+		return
+	}
+	glog.V(2).Infof("Auth request: %+v", ar)
+	{
+		authnResult, labels, err := as.Authenticate(ar)
+		if err != nil {
+			http.Error(rw, fmt.Sprintf("Authentication failed (%s)", err), http.StatusInternalServerError)
+			return
+		}
+		if !authnResult {
+			glog.Warningf("Auth failed: %s", *ar)
+			rw.Header()["WWW-Authenticate"] = []string{fmt.Sprintf(`Basic realm="%s"`, as.Token.Issuer)}
+			http.Error(rw, "Auth failed.", http.StatusUnauthorized)
+			return
+		}
+		ar.Labels = labels
+	}
+	if len(ar.Scopes) > 0 {
+		ares, err = as.Authorize(ar)
+		if err != nil {
+			http.Error(rw, fmt.Sprintf("Authorization failed (%s)", err), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		// Authentication-only request ("docker login"), pass through.
+	}
+	token, err := as.CreateToken(ar, ares)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to generate token %s", err)
+		http.Error(rw, msg, http.StatusInternalServerError)
+		glog.Errorf("%s: %s", ar, msg)
+		return
+	}
+	result, _ := json.Marshal(&map[string]string{"token": token})
+	glog.V(3).Infof("%s", result)
+	rw.Header().Set("Content-Type", "application/json")
+	rw.Write(result)
+}
+
+func (as *SimpleServer) Stop() {
+	for _, an := range as.Authenticators {
+		an.Stop()
+	}
+	for _, az := range as.Authorizers {
+		az.Stop()
+	}
+	glog.Infof("Server stopped")
+}
+
+// Copy-pasted from libtrust where it is private.
+func JoseBase64UrlEncode(b []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(b), "=")
+}

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -64,16 +64,16 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 		if err != nil {
 			glog.Exitf("Failed to load certificate and key: %s", err)
 		}
-	} else if c.Server.LetsEncrypt.Email != "" {
+	} else if c.LetsEncrypt.Email != "" {
 		m := &autocert.Manager{
-			Email:  c.Server.LetsEncrypt.Email,
-			Cache:  autocert.DirCache(c.Server.LetsEncrypt.CacheDir),
+			Email:  c.LetsEncrypt.Email,
+			Cache:  autocert.DirCache(c.LetsEncrypt.CacheDir),
 			Prompt: autocert.AcceptTOS,
 		}
-		if c.Server.LetsEncrypt.Host != "" {
-			m.HostPolicy = autocert.HostWhitelist(c.Server.LetsEncrypt.Host)
+		if c.LetsEncrypt.Host != "" {
+			m.HostPolicy = autocert.HostWhitelist(c.LetsEncrypt.Host)
 		}
-		glog.Infof("Using LetsEncrypt, host %q, email %q", c.Server.LetsEncrypt.Host, c.Server.LetsEncrypt.Email)
+		glog.Infof("Using LetsEncrypt, host %q, email %q", c.LetsEncrypt.Host, c.LetsEncrypt.Email)
 		tlsConfig.GetCertificate = m.GetCertificate
 	} else {
 		glog.Warning("Running without TLS")

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -155,9 +155,6 @@ func (rs *RestartableServer) MaybeRestart() {
 	rs.authServer, rs.hs = ServeOnce(c, rs.configFile, rs.hd)
 }
 
-var Version = "dev"
-var BuildId = "dev"
-
 func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -155,6 +155,9 @@ func (rs *RestartableServer) MaybeRestart() {
 	rs.authServer, rs.hs = ServeOnce(c, rs.configFile, rs.hd)
 }
 
+var Version = "dev"
+var BuildId = "dev"
+
 func main() {
 	flag.Parse()
 	rand.Seed(time.Now().UnixNano())

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -31,20 +31,19 @@ import (
 )
 
 type Config struct {
-	Server     ServerConfig                   `yaml:"server"`
-	Token      TokenConfig                    `yaml:"token"`
-	Users      map[string]*authn.Requirements `yaml:"users,omitempty"`
-	GoogleAuth *authn.GoogleAuthConfig        `yaml:"google_auth,omitempty"`
-	GitHubAuth *authn.GitHubAuthConfig        `yaml:"github_auth,omitempty"`
-	LDAPAuth   *authn.LDAPAuthConfig          `yaml:"ldap_auth,omitempty"`
-	MongoAuth  *authn.MongoAuthConfig         `yaml:"mongo_auth,omitempty"`
-	ExtAuth    *authn.ExtAuthConfig           `yaml:"ext_auth,omitempty"`
-	ACL        authz.ACL                      `yaml:"acl,omitempty"`
-	ACLMongo   *authz.ACLMongoConfig          `yaml:"acl_mongo,omitempty"`
-	ExtAuthz   *authz.ExtAuthzConfig          `yaml:"ext_authz,omitempty"`
-	LetsEncrypt LetsEncryptConfig             `yaml:"letsencrypt,omitempty"`
+	Server      ServerConfig                   `yaml:"server"`
+	Token       TokenConfig                    `yaml:"token"`
+	Users       map[string]*authn.Requirements `yaml:"users,omitempty"`
+	GoogleAuth  *authn.GoogleAuthConfig        `yaml:"google_auth,omitempty"`
+	GitHubAuth  *authn.GitHubAuthConfig        `yaml:"github_auth,omitempty"`
+	LDAPAuth    *authn.LDAPAuthConfig          `yaml:"ldap_auth,omitempty"`
+	MongoAuth   *authn.MongoAuthConfig         `yaml:"mongo_auth,omitempty"`
+	ExtAuth     *authn.ExtAuthConfig           `yaml:"ext_auth,omitempty"`
+	ACL         authz.ACL                      `yaml:"acl,omitempty"`
+	ACLMongo    *authz.ACLMongoConfig          `yaml:"acl_mongo,omitempty"`
+	ExtAuthz    *authz.ExtAuthzConfig          `yaml:"ext_authz,omitempty"`
+	LetsEncrypt LetsEncryptConfig              `yaml:"letsencrypt,omitempty"`
 }
-
 
 type LetsEncryptConfig struct {
 	Host     string `yaml:"host,omitempty"`

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cesanta/docker_auth/auth_server/authz"
 	. "github.com/cesanta/docker_auth/auth_server/common"
 	"github.com/cesanta/glog"
-
 )
 
 var (
@@ -35,15 +34,15 @@ var (
 type AuthServer struct {
 	*SimpleServer
 
-	config         *Config
-	ga             *authn.GoogleAuth
-	gha            *authn.GitHubAuth
+	config *Config
+	ga     *authn.GoogleAuth
+	gha    *authn.GitHubAuth
 }
 
 func NewAuthServer(c *Config) (*AuthServer, error) {
 	as := &AuthServer{
 		SimpleServer: &SimpleServer{
-			Authorizers: []Authorizer{},
+			Authorizers:    []Authorizer{},
 			Authenticators: []Authenticator{},
 		},
 		config: c,


### PR DESCRIPTION
TLDR: this is a hefty diff, but makes something like this possible:

```bash
# gen some keys
openssl req -newkey rsa:2048 -nodes -keyout registry_auth.key -x509 -days 365 -out registry_auth.crt
mv registry_auth.crt registry_auth.pem
```

```go
package main

import (
	"encoding/json"
	. "fmt"
	"io/ioutil"
	"net/http"

	. "github.com/cesanta/docker_auth/auth_server/common"
)

// SpaceAuth allows anyone to do anything, as long as there are people in space \O/
type SpaceAuth struct {
}

func (fw *SpaceAuth) Authenticate(user string, password PasswordString) (bool, Labels, error) {
	return true, nil, nil // in space, nobody can hear your name.
}

func (fw *SpaceAuth) Authorize(ai *AuthRequestInfo) ([]string, error) {
	resp, _ := http.Get("https://www.howmanypeopleareinspacerightnow.com/peopleinspace.json")
	body, _ := ioutil.ReadAll(resp.Body)
	resp.Body.Close()

	result := struct{
		Number int `json:"number"`
	}{}
	_ = json.Unmarshal(body, &result)

	if result.Number > 0 {
		Println("There are", result.Number, "in space, docker away")
		return ai.Actions, nil
	} else {
		Println("Access denied. Please create a space program to continue")
		return []string{}, nil
	}
}

func (fw *SpaceAuth) Name() string {
	return "space"
}

func (fw *SpaceAuth) Stop() { }


func main() {
	certPath := "registry_auth.pem"
	keyPath := "registry_auth.key"
	pk, prk, err := LoadCertAndKey(certPath, keyPath)

	spaceAuth := &SpaceAuth{}

	server := &SimpleServer{
		Server: ServerConfig{
			CertFile: certPath,
			KeyFile: keyPath,
		},
		Token: TokenConfig{
			Issuer: "Space",
			Expiration: 900,
			CertFile: certPath,
			KeyFile: keyPath,
			PublicKey: pk,
			PrivateKey: prk,
		},
		Authenticators: []Authenticator{spaceAuth},
		Authorizers: []Authorizer{spaceAuth},
	}

	// Or, slot this into anything! I'm using labstack/echo.
	hs := &http.Server{
		Addr:      ":6000",
		Handler:   server,
	}

	err = hs.ListenAndServe()
	Println("Served auth with err", err)
}

```

---

Hello there!

Thank you for docker_auth, it's great. I'm using it in the day job, but our specific logic is still being refined and wouldn't make sense to PR here (and probably won't interest many people if we did). I don't want to throw a maintenance burden over the fence. At the same time, we have a larger server infrastructure that I wanted to slot into. I chose to import docker_auth as a library.

To do this, I created a `auth_server/common` module to bring the interfaces into something that can be imported without also needing [the union](https://godoc.org/github.com/cesanta/docker_auth/auth_server/authz?import-graph&hide=2) of all [provider libraries](https://godoc.org/github.com/cesanta/docker_auth/auth_server/authn?import-graph&hide=2). This is probably best reviewed by commit, makes a lot more sense that way.

First, 451014c: move `authn.go` and `authz.go` to `common`. To hopefully keep conflicts with other PRs low, I just put a dot-import into the providers. I could change that out for `common.xyz` instead if you like.

Second, ee80c23: identify the core server logic, bring the weighty bits into `common.SimpleServer`. The `common` package now has a provider-agnostic server that can be dropped into any web framework, and the `server` package is fully focused on provider-specific config and functionality.

Finally, c85dcbf: little bit of gofmt. Avoided touching things I hadn't changed in this PR. Can gofmt more on request.


I think this was the simplest way to get this working. Bit of a messy birth, but I think it ended up with a pretty clean separation of concerns. What do you think? :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/238)
<!-- Reviewable:end -->
