### PR TITLE
Add circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+
+jobs:
+  build:
+
+    working_directory: /go/src/github.com/cesanta/docker_auth
+
+    docker:
+      - image: golang:1.10.3
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Dependencies
+          working_directory: auth_server
+          command: make deps
+
+      - run:
+          name: Compile
+          working_directory: auth_server
+          command: make


### PR DESCRIPTION
Added a quick circle CI config. Free service, runs fast, [looks like this](https://circleci.com/gh/kofalt/docker_auth/4).
You'll have to enable it through their app after merging.

It'd be pretty easy to add a gofmt check, or to have it save the binary after compiling so people can download test builds. The build fails right now because I invoke `make` without `Version` or `BuildId`, what would you like for me to set there?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/239)
<!-- Reviewable:end -->
