### PR TITLE
Fix broken build instructions

### DIFF
--- a/auth_server/README.md
+++ b/auth_server/README.md
@@ -1,15 +1,17 @@
 ### Building local image
 
 ```
-git clone https://github.com/cesanta/docker_auth.git
-cd docker_auth/auth_server
 # copy ca certificate to /etc/ssl/certs/ca-certificates.crt
 pip install gitpython
-mkdir /var/tmp/go
+mkdir -p /var/tmp/go/src/github.com/cesanta
+cd /var/tmp/go/src/github.com/cesanta
+git clone https://github.com/cesanta/docker_auth.git
+cd docker_auth/auth_server
 export GOPATH=/var/tmp/go
 export PATH=$PATH:$GOPATH/bin
 # download dependencies
 make deps
 # build source
+make generate
 make
 ```


### PR DESCRIPTION
The previous instructions:
 - leave the source code in the wrong place to be build
 - omit one of the steps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cesanta/docker_auth/242)
<!-- Reviewable:end -->
