### PR TITLE
Add support for lowercases DN elements

### DIFF
--- a/auth_server/authn/ldap_auth.go
+++ b/auth_server/authn/ldap_auth.go
@@ -281,7 +281,7 @@ func (la *LDAPAuth) getCNFromDN(dn string) string {
 	if err != nil || len(parsedDN.RDNs) > 0 {
 		for _, rdn := range parsedDN.RDNs {
 			for _, rdnAttr := range rdn.Attributes {
-				if rdnAttr.Type == "CN" {
+				if strings.ToUpper(rdnAttr.Type) == "CN" {
 					return rdnAttr.Value
 				}
 			}


### PR DESCRIPTION
A follow up to https://github.com/cesanta/docker_auth/pull/228#issuecomment-389545187 comment:

> FreeIPA seems to have types of DN elements lowercased

In this PR we transform DN attributes to upper case (as in most cases they are already uppercased, so it looks like it's more optimal then lowercasing) and compare to `"CN"`.