### PR TITLE
feat: extended TLS configuration

### DIFF
--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -113,7 +113,7 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 			glog.Exitf("Failed to load certificate and key: both were not provided")
 		}
 		glog.Infof("Cert file: %s", c.Server.CertFile)
-		glog.Infof("Key file: %s", c.Server.KeyFile)
+		glog.Infof("Key file : %s", c.Server.KeyFile)
 		tlsConfig.Certificates = make([]tls.Certificate, 1)
 		tlsConfig.Certificates[0], err = tls.LoadX509KeyPair(c.Server.CertFile, c.Server.KeyFile)
 		if err != nil {

--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -53,13 +53,28 @@ func ServeOnce(c *server.Config, cf string, hd *httpdown.HTTP) (*server.AuthServ
 	tlsConfig := &tls.Config{
 		PreferServerCipherSuites: true,
 	}
+	if c.Server.HSTS {
+		glog.Info("HTTP Strict Transport Security enabled")
+	}
+	if c.Server.TLSMinVersion > 0 {
+		tlsConfig.MinVersion = c.Server.TLSMinVersion
+		glog.Infof("TLS MinVersion: %#04x", tlsConfig.MinVersion)
+	}
+	if len(c.Server.TLSCurvePreferences) > 0 {
+		tlsConfig.CurvePreferences = c.Server.TLSCurvePreferences
+		glog.Infof("TLS CurvePreferences: %d", tlsConfig.CurvePreferences)
+	}
+	if len(c.Server.TLSCipherSuites) > 0 {
+		tlsConfig.CipherSuites = c.Server.TLSCipherSuites
+		glog.Infof("TLS CipherSuites: %#04x", tlsConfig.CipherSuites)
+	}
 	if c.Server.CertFile != "" || c.Server.KeyFile != "" {
 		// Check for partial configuration.
 		if c.Server.CertFile == "" || c.Server.KeyFile == "" {
 			glog.Exitf("Failed to load certificate and key: both were not provided")
 		}
 		glog.Infof("Cert file: %s", c.Server.CertFile)
-		glog.Infof("Key file : %s", c.Server.KeyFile)
+		glog.Infof("Key file: %s", c.Server.KeyFile)
 		tlsConfig.Certificates = make([]tls.Certificate, 1)
 		tlsConfig.Certificates[0], err = tls.LoadX509KeyPair(c.Server.CertFile, c.Server.KeyFile)
 		if err != nil {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -50,13 +50,17 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	ListenAddress string            `yaml:"addr,omitempty"`
-	PathPrefix    string            `yaml:"path_prefix,omitempty"`
-	RealIPHeader  string            `yaml:"real_ip_header,omitempty"`
-	RealIPPos     int               `yaml:"real_ip_pos,omitempty"`
-	CertFile      string            `yaml:"certificate,omitempty"`
-	KeyFile       string            `yaml:"key,omitempty"`
-	LetsEncrypt   LetsEncryptConfig `yaml:"letsencrypt,omitempty"`
+	ListenAddress       string            `yaml:"addr,omitempty"`
+	PathPrefix          string            `yaml:"path_prefix,omitempty"`
+	RealIPHeader        string            `yaml:"real_ip_header,omitempty"`
+	RealIPPos           int               `yaml:"real_ip_pos,omitempty"`
+	CertFile            string            `yaml:"certificate,omitempty"`
+	KeyFile             string            `yaml:"key,omitempty"`
+	HSTS                bool              `yaml:"hsts,omitempty"`
+	TLSMinVersion       uint16            `yaml:"tls_min_version,omitempty"`
+	TLSCurvePreferences []tls.CurveID     `yaml:"tls_curve_preferences,omitempty"`
+	TLSCipherSuites     []uint16          `yaml:"tls_cipher_suites,omitempty"`
+	LetsEncrypt         LetsEncryptConfig `yaml:"letsencrypt,omitempty"`
 
 	publicKey  libtrust.PublicKey
 	privateKey libtrust.PrivateKey
@@ -84,6 +88,9 @@ func validate(c *Config) error {
 	}
 	if c.Server.PathPrefix != "" && !strings.HasPrefix(c.Server.PathPrefix, "/") {
 		return errors.New("server.path_prefix must be an absolute path")
+	}
+	if c.Server.TLSMinVersion == 0x0304 && len(c.Server.TLSCipherSuites) > 0 {
+		return errors.New("TLS 1.3 ciphersuites are not configurable")
 	}
 
 	if c.Token.Issuer == "" {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -57,9 +57,9 @@ type ServerConfig struct {
 	CertFile            string            `yaml:"certificate,omitempty"`
 	KeyFile             string            `yaml:"key,omitempty"`
 	HSTS                bool              `yaml:"hsts,omitempty"`
-	TLSMinVersion       uint16            `yaml:"tls_min_version,omitempty"`
-	TLSCurvePreferences []tls.CurveID     `yaml:"tls_curve_preferences,omitempty"`
-	TLSCipherSuites     []uint16          `yaml:"tls_cipher_suites,omitempty"`
+	TLSMinVersion       string            `yaml:"tls_min_version,omitempty"`
+	TLSCurvePreferences []string          `yaml:"tls_curve_preferences,omitempty"`
+	TLSCipherSuites     []string          `yaml:"tls_cipher_suites,omitempty"`
 	LetsEncrypt         LetsEncryptConfig `yaml:"letsencrypt,omitempty"`
 
 	publicKey  libtrust.PublicKey
@@ -82,6 +82,65 @@ type TokenConfig struct {
 	privateKey libtrust.PrivateKey
 }
 
+// TLSCipherSuitesValues maps CipherSuite names as strings to the actual values
+// in the crypto/tls package
+// Taken from https://golang.org/pkg/crypto/tls/#pkg-constants
+var TLSCipherSuitesValues = map[string]uint16{
+	// TLS 1.0 - 1.2 cipher suites.
+	"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":        tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":    tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":          tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":     tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":      tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":    tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":  tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	// TLS 1.3 cipher suites.
+	"TLS_AES_128_GCM_SHA256":       tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":       tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256": tls.TLS_CHACHA20_POLY1305_SHA256,
+	// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
+	// that the client is doing version fallback. See RFC 7507.
+	"TLS_FALLBACK_SCSV": tls.TLS_FALLBACK_SCSV,
+}
+
+// TLSVersionValues maps Version names as strings to the actual values in the
+// crypto/tls package
+// Taken from https://golang.org/pkg/crypto/tls/#pkg-constants
+var TLSVersionValues = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+	// Deprecated: SSLv3 is cryptographically broken, and will be
+	// removed in Go 1.14. See golang.org/issue/32716.
+	"VersionSSL30": tls.VersionSSL30,
+}
+
+// TLSCurveIDValues maps CurveID names as strings to the actual values in the
+// crypto/tls package
+// Taken from https://golang.org/pkg/crypto/tls/#CurveID
+var TLSCurveIDValues = map[string]tls.CurveID{
+	"CurveP256": tls.CurveP256,
+	"CurveP384": tls.CurveP384,
+	"CurveP521": tls.CurveP521,
+	"X25519":    tls.X25519,
+}
+
 func validate(c *Config) error {
 	if c.Server.ListenAddress == "" {
 		return errors.New("server.addr is required")
@@ -89,10 +148,9 @@ func validate(c *Config) error {
 	if c.Server.PathPrefix != "" && !strings.HasPrefix(c.Server.PathPrefix, "/") {
 		return errors.New("server.path_prefix must be an absolute path")
 	}
-	if c.Server.TLSMinVersion == 0x0304 && len(c.Server.TLSCipherSuites) > 0 {
+	if (c.Server.TLSMinVersion == "0x0304" || c.Server.TLSMinVersion == "VersionTLS13") && c.Server.TLSCipherSuites != nil {
 		return errors.New("TLS 1.3 ciphersuites are not configurable")
 	}
-
 	if c.Token.Issuer == "" {
 		return errors.New("token.issuer is required")
 	}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -122,23 +122,23 @@ var TLSCipherSuitesValues = map[string]uint16{
 // crypto/tls package
 // Taken from https://golang.org/pkg/crypto/tls/#pkg-constants
 var TLSVersionValues = map[string]uint16{
-	"VersionTLS10": tls.VersionTLS10,
-	"VersionTLS11": tls.VersionTLS11,
-	"VersionTLS12": tls.VersionTLS12,
-	"VersionTLS13": tls.VersionTLS13,
+	"TLS10": tls.VersionTLS10,
+	"TLS11": tls.VersionTLS11,
+	"TLS12": tls.VersionTLS12,
+	"TLS13": tls.VersionTLS13,
 	// Deprecated: SSLv3 is cryptographically broken, and will be
 	// removed in Go 1.14. See golang.org/issue/32716.
-	"VersionSSL30": tls.VersionSSL30,
+	"SSL30": tls.VersionSSL30,
 }
 
 // TLSCurveIDValues maps CurveID names as strings to the actual values in the
 // crypto/tls package
 // Taken from https://golang.org/pkg/crypto/tls/#CurveID
 var TLSCurveIDValues = map[string]tls.CurveID{
-	"CurveP256": tls.CurveP256,
-	"CurveP384": tls.CurveP384,
-	"CurveP521": tls.CurveP521,
-	"X25519":    tls.X25519,
+	"P256":   tls.CurveP256,
+	"P384":   tls.CurveP384,
+	"P521":   tls.CurveP521,
+	"X25519": tls.X25519,
 }
 
 func validate(c *Config) error {
@@ -148,7 +148,7 @@ func validate(c *Config) error {
 	if c.Server.PathPrefix != "" && !strings.HasPrefix(c.Server.PathPrefix, "/") {
 		return errors.New("server.path_prefix must be an absolute path")
 	}
-	if (c.Server.TLSMinVersion == "0x0304" || c.Server.TLSMinVersion == "VersionTLS13") && c.Server.TLSCipherSuites != nil {
+	if (c.Server.TLSMinVersion == "0x0304" || c.Server.TLSMinVersion == "TLS13") && c.Server.TLSCipherSuites != nil {
 		return errors.New("TLS 1.3 ciphersuites are not configurable")
 	}
 	if c.Token.Issuer == "" {

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -349,6 +349,9 @@ func (as *AuthServer) CreateToken(ar *authRequest, ares []authzResult) (string, 
 func (as *AuthServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	glog.V(3).Infof("Request: %+v", req)
 	path_prefix := as.config.Server.PathPrefix
+	if as.config.Server.HSTS {
+		rw.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+	}
 	switch {
 	case req.URL.Path == path_prefix+"/":
 		as.doIndex(rw, req)

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -22,6 +22,29 @@ server:  # Server settings.
   # Use specific certificate and key.
   certificate: "/path/to/server.pem"
   key: "/path/to/server.key"
+  #
+  # The following optional settings will fine tune TLS configuration to improve security.
+  # Leaving them unset should be just fine for most installations.
+  #
+  # Enable HTTP Strict Transport Security.
+  # hsts: true
+  # Set minimum TLS version.
+  # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
+  # tls_min_version: 0x0303
+  # List of TLS curve preferences.
+  # Values can be found at https://golang.org/pkg/crypto/tls/#CurveID
+  # tls_curve_preferences:
+  #   - 25
+  #   - 24
+  #   - 23
+  # List of enabled TLS cipher suites.
+  # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
+  # tls_cipher_suites:
+  #   - 0xc030
+  #   - 0xc02c
+  #   - 0xc014
+  #   - 0xc00a
+
   # Use LetsEncrypt (https://letsencrypt.org/) to automatically obtain and maintain a certificate.
   # Note that this only applies to server TLS certificate, this certificate will not be used for tokens
   letsencrypt:
@@ -102,10 +125,10 @@ github_auth:
   # want to have sensitive information checked in.
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
-  # Either token_db file for storing of server tokens. 
+  # Either token_db file for storing of server tokens.
   token_db: "/somewhere/to/put/github_tokens.ldb"
-  # or google cloud storage for storing of the sensitive information. 
-  gcs_token_db: 
+  # or google cloud storage for storing of the sensitive information.
+  gcs_token_db:
     bucket: "tokenBucket"
     client_secret_file: "/path/to/client_secret.json"
   # How long to wait when talking to GitHub servers. Optional.
@@ -117,7 +140,7 @@ github_auth:
   github_web_uri: "https://github.acme.com"
   # The Github API URI in case you are using Github Enterprise.
   # Includes the protocol, without trailing slash. - defaults to: https://api.github.com
-  github_api_uri: "https://github.acme.com/api/v3" 
+  github_api_uri: "https://github.acme.com/api/v3"
   # Set an URL to display in the `docker login` command when succesfully authenticated. Optional.
   registry_url: localhost:5000
 
@@ -140,7 +163,7 @@ ldap_auth:
   # specify them here. Plain text password is read from the file.
   bind_dn:
   bind_password_file:
-  # User query settings. ${account} is expanded from auth request 
+  # User query settings. ${account} is expanded from auth request
   base: o=example.com
   filter: (&(uid=${account})(objectClass=person))
   # Labels can be mapped from LDAP attributes

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -28,20 +28,26 @@ server:  # Server settings.
   #
   # Enable HTTP Strict Transport Security.
   # hsts: true
+  #
   # Set minimum TLS version.
   # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
-  # tls_min_version: 0x0303
+  # Either the version name or its uint16 value can be specified.
+  # tls_min_version: VersionTLS12
+  #
   # List of TLS curve preferences.
   # Values can be found at https://golang.org/pkg/crypto/tls/#CurveID
+  # Either CurveID names or uint16 values can be specified.
   # tls_curve_preferences:
-  #   - 25
+  #   - CurveP521
   #   - 24
-  #   - 23
+  #   - CurveP256
+  #
   # List of enabled TLS cipher suites.
   # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
+  # Either CipherSuite names or uint16 values can be specified.
   # tls_cipher_suites:
-  #   - 0xc030
-  #   - 0xc02c
+  #   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  #   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   #   - 0xc014
   #   - 0xc00a
 

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -31,20 +31,20 @@ server:  # Server settings.
   #
   # Set minimum TLS version.
   # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
-  # Either the version name or its uint16 value can be specified.
-  # tls_min_version: VersionTLS12
+  # Either the version name (i.e. TLS11) or its uint16 value can be specified.
+  # tls_min_version: TLS12
   #
   # List of TLS curve preferences.
   # Values can be found at https://golang.org/pkg/crypto/tls/#CurveID
-  # Either CurveID names or uint16 values can be specified.
+  # Either CurveID names (i.e. P384) or uint16 values can be specified.
   # tls_curve_preferences:
-  #   - CurveP521
+  #   - P521
   #   - 24
-  #   - CurveP256
+  #   - P256
   #
   # List of enabled TLS cipher suites.
   # Values can be found at https://golang.org/pkg/crypto/tls/#pkg-constants
-  # Either CipherSuite names or uint16 values can be specified.
+  # Either CipherSuite names (i.e. TLS_RSA_WITH_RC4_128_SHA) or uint16 values can be specified.
   # tls_cipher_suites:
   #   - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   #   - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384


### PR DESCRIPTION
This PR extends the server's TLS configuration. While the default TLS settings should be enough for most use cases, if you get a bit paranoid about security you'd probably want to tweak things a bit. This PR allows that.

The motivation in my case is passing the FedRAMP certification, which required some TLS vulnerabilities to be addressed. Here's a FedRAMP compliant (as of Sep 5th, 2019) configuration example:

```yaml
server:
  addr: :5001
  certificate: /path/to/server.pem
  key: /path/to/server.key
  hsts: true
  tls_min_version: 0x0303
  tls_curve_preferences:
    - 25
    - 24
    - 23
  tls_cipher_suites:
    - 0x009c
    - 0x009d
    - 0xc02f
    - 0xc02b
    - 0xc030
    - 0xc02c
    - 0xcca8
    - 0xcca9
```
If you're curious I used [this tool](https://github.com/drwetter/testssl.sh) to test both the current server and the patched one with the settings above, and the differences are there.