### PR TITLE
Improve oAuth compatibility

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -188,6 +188,14 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 	if haveBasicAuth {
 		ar.User = user
 		ar.Password = api.PasswordString(password)
+	} else if req.Method == "POST" {
+		// username and password could be part of form data
+		username := req.FormValue("username")
+		password := req.FormValue("password")
+		if username != "" && password != "" {
+			ar.User = username
+			ar.Password = api.PasswordString(password)
+		}
 	}
 	ar.Account = req.FormValue("account")
 	if ar.Account == "" {

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -430,7 +430,10 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 		glog.Errorf("%s: %s", ar, msg)
 		return
 	}
-	result, _ := json.Marshal(&map[string]string{"token": token})
+	// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+	// describes that the response should have the token in `access_token` but
+	// sometimes `token` is accepted as well. We'll support both
+	result, _ := json.Marshal(&map[string]string{"token": token, "access_token": token})
 	glog.V(3).Infof("%s", result)
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Write(result)

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -431,9 +431,8 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
-	// describes that the response should have the token in `access_token` but
-	// sometimes `token` is accepted as well. We'll support both
-	result, _ := json.Marshal(&map[string]string{"token": token, "access_token": token})
+	// describes that the response should have the token in `access_token`
+	result, _ := json.Marshal(&map[string]string{"access_token": token})
 	glog.V(3).Infof("%s", result)
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Write(result)


### PR DESCRIPTION
I've been trying to get containerd and cesenta to play nice in terms of authentication. After some digging I found out authentication doesn't work because containerd is

- doing POST requests during authorization with username/password in the formdata instead of Basic Authentication and docker_auth doesn't recognise this. 
- the JSON that is responded with holds the token in `token` where the oAuth specification tells me it should be `access_token`.

At first I patched this in containerd itself (https://github.com/containerd/containerd/pull/3795) but the devs over there convinced me they are following the spec and docker_auth should be fixed. So that's what this PR is trying to achieve and I think it's fully backwards compatible. 

Below is the output before and after the patch, when I run:
```bash
$ ctr images pull -user skoef:mypassword myregistry.local/skoef/nginx:latest
```

Before:
```
I1105 09:09:59.513631   11268 server.go:334] Request: &{Method:POST URL:/auth Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Content-Length:[184] Content-Type:[application/x-www-form-urlencoded; charset=utf-8] Accept-Encoding:[gzip] User-Agent:[Go-http-client/1.1]] Body:0xc4201fc400 GetBody:<nil> ContentLength:184 TransferEncoding:[] Close:false Host:myregistry.local:5001 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr:192.168.100.10:40756 RequestURI:/auth TLS:0xc4200bcf20 Cancel:<nil> Response:<nil> ctx:0xc4201fc440}
I1105 09:09:59.513979   11268 server.go:371] Auth request: {:@192.168.100.10:40756 [{repository skoef/myapp [pull]}]}
I1105 09:09:59.514038   11268 server.go:217] Authn static  -> true, map[], <nil>
I1105 09:09:59.514360   11268 server.go:239] Authz static ACL { pull repository skoef/myapp} -> [], did not match any rule
W1105 09:09:59.514387   11268 server.go:251] { pull repository skoef/myapp} did not match any authz rule
I1105 09:09:59.591034   11268 server.go:329] New token for {:@192.168.100.10:40756 [{repository skoef/myapp [pull]}]} map[]: {"iss":"My Private Registry","sub":"","aud":"Docker registry","exp":1572942299,"nbf":1572941389,"iat":1572941399,"jti":"4562032760727769120","access":[{"type":"repository","name":"skoef/myapp","actions":[]}]}
I1105 09:09:59.591178   11268 server.go:403] {"token":"...token.data..."}
```
After
```
I1105 09:10:54.182929   14324 server.go:369] Request: &{Method:POST URL:/auth Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Accept-Encoding:[gzip] Content-Length:[184] Content-Type:[application/x-www-form-urlencoded; charset=utf-8] User-Agent:[Go-http-client/1.1]] Body:0xc0002aa300 GetBody:<nil> ContentLength:184 TransferEncoding:[] Close:false Host:myregistry.local:5001 Form:map[] PostForm:map[] MultipartForm:<nil> Trailer:map[] RemoteAddr:192.168.100.10:40808 RequestURI:/auth TLS:0xc0000a3a20 Cancel:<nil> Response:<nil> ctx:0xc0002aa340}
I1105 09:10:54.183360   14324 server.go:413] Auth request: {skoef:***@192.168.100.10:40808 [{repository skoef/myapp [pull]}]}
I1105 09:10:54.186821   14324 server.go:252] Authn static skoef -> true, map[], <nil>
I1105 09:10:54.186938   14324 acl.go:117] {skoef pull repository skoef/myapp} matched {"Match":{"account":"skoef","ip":"192.168.100.0/24"},"Actions":["*"],"Comment":"Allow skoef to pull any image"} (Comment: %!s(*string=0xc0002374b0))
I1105 09:10:54.187121   14324 server.go:274] Authz static ACL {skoef pull repository skoef/myapp} -> [pull], %!s(<nil>)
I1105 09:10:54.232180   14324 server.go:364] New token for {skoef:***@192.168.100.10:40808 [{repository skoef/myapp [pull]}]} map[]: {"iss":"My Private Registry","sub":"skoef","aud":"Docker registry","exp":1572942354,"nbf":1572941444,"iat":1572941454,"jti":"5811205348159000518","access":[{"type":"repository","name":"skoef/myapp","actions":["pull"]}]}
I1105 09:10:54.232557   14324 server.go:445] {"access_token":"...token.data...","token":"...the.same.token.data..."}
```

Needless to say, the second time I did succeed in pulling the image.