### PR TITLE
Fix scope parsing

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -226,37 +226,38 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 		return nil, fmt.Errorf("invalid form value")
 	}
 	// https://github.com/docker/distribution/blob/1b9ab303a477ded9bdd3fc97e9119fa8f9e58fca/docs/spec/auth/scope.md#resource-scope-grammar
-	scopeValue := req.FormValue("scope")
-	if scopeValue != "" {
-		for _, scopeStr := range strings.Split(scopeValue, " ") {
-			parts := strings.Split(scopeStr, ":")
-			var scope authScope
+	if req.FormValue("scope") != "" {
+		for _, scopeValue := range req.Form["scope"] {
+			for _, scopeStr := range strings.Split(scopeValue, " ") {
+				parts := strings.Split(scopeStr, ":")
+				var scope authScope
 
-			scopeType, scopeClass, err := parseScope(parts[0])
-			if err != nil {
-				return nil, err
-			}
+				scopeType, scopeClass, err := parseScope(parts[0])
+				if err != nil {
+					return nil, err
+				}
 
-			switch len(parts) {
-			case 3:
-				scope = authScope{
-					Type:    scopeType,
-					Class:   scopeClass,
-					Name:    parts[1],
-					Actions: strings.Split(parts[2], ","),
+				switch len(parts) {
+				case 3:
+					scope = authScope{
+						Type:    scopeType,
+						Class:   scopeClass,
+						Name:    parts[1],
+						Actions: strings.Split(parts[2], ","),
+					}
+				case 4:
+					scope = authScope{
+						Type:    scopeType,
+						Class:   scopeClass,
+						Name:    parts[1] + ":" + parts[2],
+						Actions: strings.Split(parts[3], ","),
+					}
+				default:
+					return nil, fmt.Errorf("invalid scope: %q", scopeStr)
 				}
-			case 4:
-				scope = authScope{
-					Type:    scopeType,
-					Class:   scopeClass,
-					Name:    parts[1] + ":" + parts[2],
-					Actions: strings.Split(parts[3], ","),
-				}
-			default:
-				return nil, fmt.Errorf("invalid scope: %q", scopeStr)
+				sort.Strings(scope.Actions)
+				ar.Scopes = append(ar.Scopes, scope)
 			}
-			sort.Strings(scope.Actions)
-			ar.Scopes = append(ar.Scopes, scope)
 		}
 	}
 	return ar, nil
@@ -460,7 +461,7 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 	// https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
 	// describes that the response should have the token in `access_token`
 	// https://docs.docker.com/registry/spec/auth/token/#token-response-fields
-	// the token should also be in `token` to support older clients 
+	// the token should also be in `token` to support older clients
 	result, _ := json.Marshal(&map[string]string{"access_token": token, "token": token})
 	glog.V(3).Infof("%s", result)
 	rw.Header().Set("Content-Type", "application/json")

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -226,8 +226,9 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 		return nil, fmt.Errorf("invalid form value")
 	}
 	// https://github.com/docker/distribution/blob/1b9ab303a477ded9bdd3fc97e9119fa8f9e58fca/docs/spec/auth/scope.md#resource-scope-grammar
-	if req.FormValue("scope") != "" {
-		for _, scopeStr := range req.Form["scope"] {
+	scopeValue := req.FormValue("scope")
+	if scopeValue != "" {
+		for _, scopeStr := range strings.Split(scopeValue, " ") {
 			parts := strings.Split(scopeStr, ":")
 			var scope authScope
 


### PR DESCRIPTION
Per
https://docs.docker.com/registry/spec/auth/scope/#resource-scope-grammar
and https://docs.docker.com/registry/spec/auth/oauth/
multiple scopes are separated by a single space within a single `scope`
parameter.

This fixes compatibility with buildkit which currently generates a bad request when pushing:

``` sh
W0306 15:29:11.332525      31 server.go:424] Bad request: invalid scope: "repository:my-registry.com/my-repo:pull repository:my-registry.com/my-repo:pull,push"
```