### PR TITLE
Fix Docker Hub link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Supported authorization methods:
 
 ## Installation and Examples
 
-A public Docker image is available on Docker Hub: [cesanta/docker_auth](https://registry.hub.docker.com/u/cesanta/docker_auth/).
+A public Docker image is available on Docker Hub: [cesanta/docker_auth](https://registry.hub.docker.com/r/cesanta/docker_auth/).
 
 Tags available:
  - `:latest` - bleeding edge, usually works but breaking config changes are possible. You probably do not want to use this in production.


### PR DESCRIPTION
Really just a tiny documentation fix, but the Docker Hub link in the README.md currently points to a wrong URL, leading the reader to an empty page.