### PR TITLE
Fix go vet failures

### DIFF
--- a/auth_server/authz/acl.go
+++ b/auth_server/authz/acl.go
@@ -114,7 +114,11 @@ func (aa *aclAuthorizer) Authorize(ai *api.AuthRequestInfo) ([]string, error) {
 	for _, e := range aa.acl {
 		matched := e.Matches(ai)
 		if matched {
-			glog.V(2).Infof("%s matched %s (Comment: %s)", ai, e, e.Comment)
+			comment := "(nil)"
+			if e.Comment != nil {
+				comment = *e.Comment
+			}
+			glog.V(2).Infof("%s matched %s (Comment: %s)", ai, e, comment)
 			if len(*e.Actions) == 1 && (*e.Actions)[0] == "*" {
 				return ai.Actions, nil
 			}

--- a/auth_server/authz/acl_test.go
+++ b/auth_server/authz/acl_test.go
@@ -49,9 +49,9 @@ func TestValidation(t *testing.T) {
 	for i, c := range cases {
 		result := validateMatchConditions(&c.mc)
 		if c.ok && result != nil {
-			t.Errorf("%d: %q: expected to pass, got %s", i, c.mc, result)
+			t.Errorf("%d: %v: expected to pass, got %s", i, c.mc, result)
 		} else if !c.ok && result == nil {
-			t.Errorf("%d: %q: expected to fail, but it passed", i, c.mc)
+			t.Errorf("%d: %v: expected to fail, but it passed", i, c.mc)
 		}
 	}
 }


### PR DESCRIPTION
Recent Go updates cause test failures when there are issues found via `go vet`, including `fmt.Printf`-based misuse.

This is causing `go test ./...` to fail on `master`:

```
$ go test ./...
# github.com/cesanta/docker_auth/auth_server/authz
authz/acl.go:117:4: Infof format %s has arg e.Comment of wrong type *string
authz/acl_test.go:52:4: Errorf format %q has arg c.mc of wrong type github.com/cesanta/docker_auth/auth_server/authz.MatchConditions
authz/acl_test.go:54:4: Errorf format %q has arg c.mc of wrong type github.com/cesanta/docker_auth/auth_server/authz.MatchConditions
?   	github.com/cesanta/docker_auth/auth_server	[no test files]
?   	github.com/cesanta/docker_auth/auth_server/api	[no test files]
ok  	github.com/cesanta/docker_auth/auth_server/authn	0.091s
FAIL	github.com/cesanta/docker_auth/auth_server/authz [build failed]
?   	github.com/cesanta/docker_auth/auth_server/mgo_session	[no test files]
?   	github.com/cesanta/docker_auth/auth_server/server	[no test files]
FAIL
```

This updates `Printf` related calls.

```
$ go test ./...
?   	github.com/cesanta/docker_auth/auth_server	[no test files]
?   	github.com/cesanta/docker_auth/auth_server/api	[no test files]
ok  	github.com/cesanta/docker_auth/auth_server/authn	(cached)
ok  	github.com/cesanta/docker_auth/auth_server/authz	0.037s
?   	github.com/cesanta/docker_auth/auth_server/mgo_session	[no test files]
?   	github.com/cesanta/docker_auth/auth_server/server	[no test files]
```