### PR TITLE
Bring Redis and GCS token storage to Google Auth provider

### DIFF
--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -179,7 +179,7 @@ func NewGitHubAuth(c *GitHubAuthConfig) (*GitHubAuth, error) {
 		db, err = NewRedisTokenDB(c.RedisTokenDB)
 		dbName = db.(*redisTokenDB).String()
 	default:
-		db, err = NewTokenDB(c.TokenDB)
+		db, err = NewLevelDBTokenDB(c.TokenDB)
 	}
 
 	if err != nil {

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -155,25 +155,11 @@ func parseLinkHeader(linkLines []string) (linkHeader, error) {
 }
 
 func NewGitHubAuth(c *GitHubAuthConfig) (*GitHubAuth, error) {
-	var db TokenDB
-	var err error
-	dbName := c.TokenDB
-
-	switch {
-	case c.GCSTokenDB != nil:
-		db, err = NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
-		dbName = "GCS: " + c.GCSTokenDB.Bucket
-	case c.RedisTokenDB != nil:
-		db, err = NewRedisTokenDB(c.RedisTokenDB)
-		dbName = db.(*redisTokenDB).String()
-	default:
-		db, err = NewLevelDBTokenDB(c.TokenDB)
-	}
-
+	db, err := NewTokenDB(c.TokenConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize token storage: %w", err)
 	}
-	glog.Infof("GitHub auth token DB at %s", dbName)
+	glog.Infof("GitHub auth token DB at %s", db)
 	return &GitHubAuth{
 		config:     c,
 		db:         db,

--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/cesanta/glog"
-	"github.com/go-redis/redis"
 
 	"github.com/cesanta/docker_auth/auth_server/api"
 )
@@ -57,28 +56,17 @@ type ParentGitHubTeam struct {
 }
 
 type GitHubAuthConfig struct {
-	Organization     string                  `yaml:"organization,omitempty"`
-	ClientId         string                  `yaml:"client_id,omitempty"`
-	ClientSecret     string                  `yaml:"client_secret,omitempty"`
-	ClientSecretFile string                  `yaml:"client_secret_file,omitempty"`
-	TokenDB          string                  `yaml:"token_db,omitempty"`
-	GCSTokenDB       *GitHubGCSStoreConfig   `yaml:"gcs_token_db,omitempty"`
-	RedisTokenDB     *GitHubRedisStoreConfig `yaml:"redis_token_db,omitempty"`
-	HTTPTimeout      time.Duration           `yaml:"http_timeout,omitempty"`
-	RevalidateAfter  time.Duration           `yaml:"revalidate_after,omitempty"`
-	GithubWebUri     string                  `yaml:"github_web_uri,omitempty"`
-	GithubApiUri     string                  `yaml:"github_api_uri,omitempty"`
-	RegistryUrl      string                  `yaml:"registry_url,omitempty"`
-}
+	TokenConfiguration `yaml:",inline"`
 
-type GitHubGCSStoreConfig struct {
-	Bucket           string `yaml:"bucket,omitempty"`
-	ClientSecretFile string `yaml:"client_secret_file,omitempty"`
-}
-
-type GitHubRedisStoreConfig struct {
-	ClientOptions  *redis.Options        `yaml:"redis_options,omitempty"`
-	ClusterOptions *redis.ClusterOptions `yaml:"redis_cluster_options,omitempty"`
+	Organization     string        `yaml:"organization,omitempty"`
+	ClientId         string        `yaml:"client_id,omitempty"`
+	ClientSecret     string        `yaml:"client_secret,omitempty"`
+	ClientSecretFile string        `yaml:"client_secret_file,omitempty"`
+	HTTPTimeout      time.Duration `yaml:"http_timeout,omitempty"`
+	RevalidateAfter  time.Duration `yaml:"revalidate_after,omitempty"`
+	GithubWebUri     string        `yaml:"github_web_uri,omitempty"`
+	GithubApiUri     string        `yaml:"github_api_uri,omitempty"`
+	RegistryUrl      string        `yaml:"registry_url,omitempty"`
 }
 
 type GitHubAuthRequest struct {

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -127,7 +127,7 @@ type GoogleAuth struct {
 }
 
 func NewGoogleAuth(c *GoogleAuthConfig) (*GoogleAuth, error) {
-	db, err := NewTokenDB(c.TokenDB)
+	db, err := NewLevelDBTokenDB(c.TokenDB)
 	if err != nil {
 		return nil, err
 	}

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -33,12 +33,12 @@ import (
 )
 
 type GoogleAuthConfig struct {
-	Domain           string `yaml:"domain,omitempty"`
-	ClientId         string `yaml:"client_id,omitempty"`
-	ClientSecret     string `yaml:"client_secret,omitempty"`
-	ClientSecretFile string `yaml:"client_secret_file,omitempty"`
-	TokenDB          string `yaml:"token_db,omitempty"`
-	HTTPTimeout      int    `yaml:"http_timeout,omitempty"`
+	TokenConfiguration `yaml:",inline"`
+	Domain             string `yaml:"domain,omitempty"`
+	ClientId           string `yaml:"client_id,omitempty"`
+	ClientSecret       string `yaml:"client_secret,omitempty"`
+	ClientSecretFile   string `yaml:"client_secret_file,omitempty"`
+	HTTPTimeout        int    `yaml:"http_timeout,omitempty"`
 }
 
 type GoogleAuthRequest struct {
@@ -127,11 +127,11 @@ type GoogleAuth struct {
 }
 
 func NewGoogleAuth(c *GoogleAuthConfig) (*GoogleAuth, error) {
-	db, err := NewLevelDBTokenDB(c.TokenDB)
+	db, err := NewTokenDB(c.TokenConfiguration)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to initialize token storage: %w", err)
 	}
-	glog.Infof("Google auth token DB at %s", c.TokenDB)
+	glog.Infof("Google auth token DB at %s", db)
 	return &GoogleAuth{
 		config: c,
 		db:     db,

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -47,8 +47,11 @@ type TokenDB interface {
 	// and deletes the corresponding token from the DB
 	DeleteToken(string) error
 
-	// Composed from leveldb.DB
+	// Close cleans up any resources
 	Close() error
+
+	// String returns a short description
+	String() string
 }
 
 // TokenDBValue is stored in the database, JSON-serialized.
@@ -82,4 +85,13 @@ type RedisTokenConfig struct {
 	ClusterOptions *redis.ClusterOptions `yaml:"redis_cluster_options,omitempty"`
 }
 
-// func NewTokenDB(filename string)
+// NewTokenDB returns the TokenDB specified by the given configuration (GCS, Redis or LevelDB)
+func NewTokenDB(c TokenConfiguration) (TokenDB, error) {
+	if c.GCSTokenDB != nil {
+		return NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
+	}
+	if c.RedisTokenDB != nil {
+		return NewRedisTokenDB(c.RedisTokenDB)
+	}
+	return NewLevelDBTokenDB(c.TokenDB)
+}

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -17,15 +17,8 @@
 package authn
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
-
-	"github.com/cesanta/glog"
-	"github.com/dchest/uniuri"
-	"github.com/syndtr/goleveldb/leveldb"
-	"golang.org/x/crypto/bcrypt"
 
 	"github.com/cesanta/docker_auth/auth_server/api"
 )
@@ -57,11 +50,6 @@ type TokenDB interface {
 	Close() error
 }
 
-// TokenDB stores tokens using LevelDB
-type TokenDBImpl struct {
-	*leveldb.DB
-}
-
 // TokenDBValue is stored in the database, JSON-serialized.
 type TokenDBValue struct {
 	TokenType    string    `json:"token_type,omitempty"` // Usually "Bearer"
@@ -72,78 +60,4 @@ type TokenDBValue struct {
 	// Generated at the time of token creation, stored here as a BCrypt hash.
 	DockerPassword string     `json:"docker_password,omitempty"`
 	Labels         api.Labels `json:"labels,omitempty"`
-}
-
-// NewTokenDB returns a new TokenDB structure
-func NewTokenDB(file string) (TokenDB, error) {
-	db, err := leveldb.OpenFile(file, nil)
-	return &TokenDBImpl{
-		DB: db,
-	}, err
-}
-
-func (db *TokenDBImpl) GetValue(user string) (*TokenDBValue, error) {
-	valueStr, err := db.Get(getDBKey(user), nil)
-	switch {
-	case err == leveldb.ErrNotFound:
-		return nil, nil
-	case err != nil:
-		glog.Errorf("error accessing token db: %s", err)
-		return nil, fmt.Errorf("error accessing token db: %s", err)
-	}
-	var dbv TokenDBValue
-	err = json.Unmarshal(valueStr, &dbv)
-	if err != nil {
-		glog.Errorf("bad DB value for %q (%q): %s", user, string(valueStr), err)
-		return nil, fmt.Errorf("bad DB value due: %v", err)
-	}
-	return &dbv, nil
-}
-
-func (db *TokenDBImpl) StoreToken(user string, v *TokenDBValue, updatePassword bool) (dp string, err error) {
-	if updatePassword {
-		dp = uniuri.New()
-		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), bcrypt.DefaultCost)
-		v.DockerPassword = string(dph)
-	}
-
-	data, err := json.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	err = db.Put(getDBKey(user), data, nil)
-	if err != nil {
-		glog.Errorf("failed to set token data for %s: %s", user, err)
-	}
-	glog.V(2).Infof("Server tokens for %s: %s", user, string(data))
-	return
-}
-
-func (db *TokenDBImpl) ValidateToken(user string, password api.PasswordString) error {
-	dbv, err := db.GetValue(user)
-	if err != nil {
-		return err
-	}
-	if dbv == nil {
-		return api.NoMatch
-	}
-	if bcrypt.CompareHashAndPassword([]byte(dbv.DockerPassword), []byte(password)) != nil {
-		return api.WrongPass
-	}
-	if time.Now().After(dbv.ValidUntil) {
-		return ExpiredToken
-	}
-	return nil
-}
-
-func (db *TokenDBImpl) DeleteToken(user string) error {
-	glog.V(1).Infof("deleting token for %s", user)
-	if err := db.Delete(getDBKey(user), nil); err != nil {
-		return fmt.Errorf("failed to delete %s: %s", user, err)
-	}
-	return nil
-}
-
-func getDBKey(user string) []byte {
-	return []byte(fmt.Sprintf("%s%s", tokenDBPrefix, user))
 }

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -29,7 +29,7 @@ const (
 
 var ExpiredToken = errors.New("expired token")
 
-// TokenDB stores tokens using LevelDB
+// TokenDB stores and validates tokens from external authentication providers
 type TokenDB interface {
 	// GetValue takes a username returns the corresponding token
 	GetValue(string) (*TokenDBValue, error)

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -73,6 +73,13 @@ type TokenConfiguration struct {
 	RedisTokenDB *RedisTokenConfig `yaml:"redis_token_db,omitempty"`
 }
 
+func (t TokenConfiguration) Validate() error {
+	if t.TokenDB == "" && t.GCSTokenDB == nil && t.RedisTokenDB == nil {
+		return errors.New("one of token_db, gcs_token_db or redis_token_db must be specified")
+	}
+	return nil
+}
+
 // GCSTokenConfig is Google Cloud Storage-based token storage configuration
 type GCSTokenConfig struct {
 	Bucket           string `yaml:"bucket,omitempty"`

--- a/auth_server/authn/tokendb.go
+++ b/auth_server/authn/tokendb.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cesanta/docker_auth/auth_server/api"
+	"github.com/go-redis/redis"
 )
 
 const (
@@ -61,3 +62,24 @@ type TokenDBValue struct {
 	DockerPassword string     `json:"docker_password,omitempty"`
 	Labels         api.Labels `json:"labels,omitempty"`
 }
+
+// TokenConfiguration is a shared YAML configuration structure for multiple token types
+type TokenConfiguration struct {
+	TokenDB      string            `yaml:"token_db,omitempty"`
+	GCSTokenDB   *GCSTokenConfig   `yaml:"gcs_token_db,omitempty"`
+	RedisTokenDB *RedisTokenConfig `yaml:"redis_token_db,omitempty"`
+}
+
+// GCSTokenConfig is Google Cloud Storage-based token storage configuration
+type GCSTokenConfig struct {
+	Bucket           string `yaml:"bucket,omitempty"`
+	ClientSecretFile string `yaml:"client_secret_file,omitempty"`
+}
+
+// RedisTokenConfig is Redis-based token storage configuration
+type RedisTokenConfig struct {
+	ClientOptions  *redis.Options        `yaml:"redis_options,omitempty"`
+	ClusterOptions *redis.ClusterOptions `yaml:"redis_cluster_options,omitempty"`
+}
+
+// func NewTokenDB(filename string)

--- a/auth_server/authn/tokendb_gcs.go
+++ b/auth_server/authn/tokendb_gcs.go
@@ -121,3 +121,8 @@ func (db *gcsTokenDB) DeleteToken(user string) error {
 func (db *gcsTokenDB) Close() error {
 	return nil
 }
+
+// String returns "GCS: " plus the bucket path
+func (db *gcsTokenDB) String() string {
+	return "GCS: " + db.bucket
+}

--- a/auth_server/authn/tokendb_leveldb.go
+++ b/auth_server/authn/tokendb_leveldb.go
@@ -15,13 +15,16 @@ import (
 
 type leveldbTokenDB struct {
 	*leveldb.DB
+
+	filename string
 }
 
 // NewLevelDBTokenDB returns LevelDB-based token instance
 func NewLevelDBTokenDB(file string) (TokenDB, error) {
 	db, err := leveldb.OpenFile(file, nil)
 	return &leveldbTokenDB{
-		DB: db,
+		DB:       db,
+		filename: file,
 	}, err
 }
 
@@ -85,6 +88,10 @@ func (db *leveldbTokenDB) DeleteToken(user string) error {
 		return fmt.Errorf("failed to delete %s: %s", user, err)
 	}
 	return nil
+}
+
+func (db *leveldbTokenDB) String() string {
+	return db.filename
 }
 
 func getDBKey(user string) []byte {

--- a/auth_server/authn/tokendb_leveldb.go
+++ b/auth_server/authn/tokendb_leveldb.go
@@ -1,0 +1,93 @@
+package authn
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cesanta/glog"
+	"github.com/dchest/uniuri"
+	"github.com/syndtr/goleveldb/leveldb"
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/cesanta/docker_auth/auth_server/api"
+)
+
+// TokenDB stores tokens using LevelDB
+type TokenDBImpl struct {
+	*leveldb.DB
+}
+
+// NewTokenDB returns a new TokenDB structure
+func NewTokenDB(file string) (TokenDB, error) {
+	db, err := leveldb.OpenFile(file, nil)
+	return &TokenDBImpl{
+		DB: db,
+	}, err
+}
+
+func (db *TokenDBImpl) GetValue(user string) (*TokenDBValue, error) {
+	valueStr, err := db.Get(getDBKey(user), nil)
+	switch {
+	case err == leveldb.ErrNotFound:
+		return nil, nil
+	case err != nil:
+		glog.Errorf("error accessing token db: %s", err)
+		return nil, fmt.Errorf("error accessing token db: %s", err)
+	}
+	var dbv TokenDBValue
+	err = json.Unmarshal(valueStr, &dbv)
+	if err != nil {
+		glog.Errorf("bad DB value for %q (%q): %s", user, string(valueStr), err)
+		return nil, fmt.Errorf("bad DB value due: %v", err)
+	}
+	return &dbv, nil
+}
+
+func (db *TokenDBImpl) StoreToken(user string, v *TokenDBValue, updatePassword bool) (dp string, err error) {
+	if updatePassword {
+		dp = uniuri.New()
+		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), bcrypt.DefaultCost)
+		v.DockerPassword = string(dph)
+	}
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	err = db.Put(getDBKey(user), data, nil)
+	if err != nil {
+		glog.Errorf("failed to set token data for %s: %s", user, err)
+	}
+	glog.V(2).Infof("Server tokens for %s: %s", user, string(data))
+	return
+}
+
+func (db *TokenDBImpl) ValidateToken(user string, password api.PasswordString) error {
+	dbv, err := db.GetValue(user)
+	if err != nil {
+		return err
+	}
+	if dbv == nil {
+		return api.NoMatch
+	}
+	if bcrypt.CompareHashAndPassword([]byte(dbv.DockerPassword), []byte(password)) != nil {
+		return api.WrongPass
+	}
+	if time.Now().After(dbv.ValidUntil) {
+		return ExpiredToken
+	}
+	return nil
+}
+
+func (db *TokenDBImpl) DeleteToken(user string) error {
+	glog.V(1).Infof("deleting token for %s", user)
+	if err := db.Delete(getDBKey(user), nil); err != nil {
+		return fmt.Errorf("failed to delete %s: %s", user, err)
+	}
+	return nil
+}
+
+func getDBKey(user string) []byte {
+	return []byte(fmt.Sprintf("%s%s", tokenDBPrefix, user))
+}

--- a/auth_server/authn/tokendb_redis.go
+++ b/auth_server/authn/tokendb_redis.go
@@ -21,7 +21,7 @@ type RedisClient interface {
 
 // NewRedisTokenDB returns a new TokenDB structure which uses Redis as the storage backend.
 //
-func NewRedisTokenDB(options *GitHubRedisStoreConfig) (TokenDB, error) {
+func NewRedisTokenDB(options *RedisTokenConfig) (TokenDB, error) {
 	var client RedisClient
 	if options.ClusterOptions != nil {
 		if options.ClientOptions != nil {

--- a/auth_server/authn/tokendb_test.go
+++ b/auth_server/authn/tokendb_test.go
@@ -1,0 +1,75 @@
+package authn
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-redis/redis"
+)
+
+func TestNewTokenDB(t *testing.T) {
+	t.Run("LevelDB config", func(t *testing.T) {
+		defer os.RemoveAll("testdata/example-db")
+		cfg := TokenConfiguration{
+			TokenDB: "testdata/example-db",
+		}
+		db, err := NewTokenDB(cfg)
+
+		if err != nil {
+			t.Fatalf("Expected no error from NewTokenDB(), got %s", err.Error())
+		}
+		defer db.Close()
+
+		if _, ok := db.(*leveldbTokenDB); !ok {
+			t.Fatalf("Unexpected underlying type for db, got %#v", db)
+		}
+		if db.String() != "testdata/example-db" {
+			t.Fatalf("Expected db.String() to be %q, got %q", "testdata/example-db", db.String())
+		}
+	})
+
+	t.Run("GCS config", func(t *testing.T) {
+		cfg := TokenConfiguration{
+			GCSTokenDB: &GCSTokenConfig{
+				Bucket:           "bucket",
+				ClientSecretFile: "testdata/gcs-credential-file.json",
+			},
+		}
+		db, err := NewTokenDB(cfg)
+
+		if err != nil {
+			t.Fatalf("Expected no error from NewTokenDB(), got %s", err.Error())
+		}
+		defer db.Close()
+
+		if _, ok := db.(*gcsTokenDB); !ok {
+			t.Fatalf("Unexpected underlying type for db, got %#v", db)
+		}
+		if db.String() != "GCS: bucket" {
+			t.Fatalf("Expected db.String() to be %q, got %q", "GCS: bucket", db.String())
+		}
+	})
+
+	t.Run("Redis config", func(t *testing.T) {
+		cfg := TokenConfiguration{
+			RedisTokenDB: &RedisTokenConfig{
+				ClientOptions: &redis.Options{
+					Password: "rofl",
+				},
+			},
+		}
+		db, err := NewTokenDB(cfg)
+
+		if err != nil {
+			t.Fatalf("Expected no error from NewTokenDB(), got %s", err.Error())
+		}
+		defer db.Close()
+
+		if _, ok := db.(*redisTokenDB); !ok {
+			t.Fatalf("Unexpected underlying type for db, got %#v", db)
+		}
+		if db.String() != "Redis<localhost:6379 db:0>" {
+			t.Fatalf("Expected db.String() to be %q, got %q", "Redis<localhost:6379 db:0>", db.String())
+		}
+	})
+}

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -173,8 +173,11 @@ func validate(c *Config) error {
 			}
 			gac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if gac.ClientId == "" || gac.ClientSecret == "" || gac.TokenDB == "" {
-			return errors.New("google_auth.{client_id,client_secret,token_db} are required.")
+		if gac.ClientId == "" || gac.ClientSecret == "" {
+			return errors.New("google_auth.{client_id,client_secret} are required")
+		}
+		if err := gac.TokenConfiguration.Validate(); err != nil {
+			return fmt.Errorf("invalid google_auth: %w", err)
 		}
 		if gac.HTTPTimeout <= 0 {
 			gac.HTTPTimeout = 10

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -110,8 +110,20 @@ google_auth:
   # want to have sensitive information checked in.
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
-  # Where to store server tokens. Required.
+  # Either token_db file for storing of server tokens.
   token_db: "/somewhere/to/put/google_tokens.ldb"
+  # or google cloud storage for storing of the sensitive information,
+  gcs_token_db:
+    bucket: "tokenBucket"
+    client_secret_file: "/path/to/client_secret.json"
+  # or Redis,
+  redis_token_db:
+    redis_options:
+        # with a single instance,
+        addr: localhost:6379
+    redis_cluster_options:
+        # or in the cluster mode.
+        addrs: ["localhost:7000"]
   # How long to wait when talking to Google servers. Optional.
   http_timeout: 10
 


### PR DESCRIPTION
Fixes/implements #126 

This adds the existing Redis/Google Cloud Storage of temporary auth tokens (used in the GitHub implementation) to Google Auth.

This PR is best viewed commit-by-commit, and hiding whitespace changes.

I've pulled the token DB initialization from GitHub in to a common implementation that returns the `TokenDB` interface in `tokendb.go`. In doing so I also pulled the common configuration options in to their own `TokenConfiguration` struct and composed it in to the Google-specific struct, and back in to the GitHub one.

I have some tests to confirm the common TokenDB initializer is correct, but to test the configuration changes I've run the binary manually with updated `config.yml`:

Google Auth:

```
$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
google_auth.go:134] Google auth token DB at ./google_tokens.ldb
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
google_auth.go:419] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting

$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
google_auth.go:134] Google auth token DB at GCS: tokenBucket
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
google_auth.go:419] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting

$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
google_auth.go:134] Google auth token DB at Redis<localhost:6379 db:0>
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
google_auth.go:419] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting
```

GitHub Auth:

```
$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
github_auth.go:162] GitHub auth token DB at ./github_tokens.ldb
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
github_auth.go:480] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting

$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
github_auth.go:162] GitHub auth token DB at GCS: tokenBucket
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
github_auth.go:480] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting

$ ./auth_server -alsologtostderr config.yml
main.go:208] docker_auth 1.2.3.4 build 2.3.4.5
main.go:56] Config from config.yml (3 users, 18 ACL static entries)
github_auth.go:162] GitHub auth token DB at Redis<localhost:6379 db:0>
main.go:124] Running without TLS
main.go:137] Serving on :5001
main.go:182] Signal: interrupt
github_auth.go:480] Token DB closed
server.go:478] Server stopped
main.go:185] Exiting
```
