### PR TITLE
Move to Python3

### DIFF
--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -30,7 +30,7 @@ ca-certificates.crt:
 build-release: ca-certificates.crt
 	docker run --rm -v $(PWD)/..:/src \
 	  $(BUILDER_IMAGE) sh -x -c "\
-	    apk update && apk add git make py2-pip && pip install GitPython && \
+	    apk update && apk add git make py-pip && pip install GitPython && \
 	    cd /src/auth_server && \
 	    umask 0 && \
 	    go install -v github.com/a-urth/go-bindata/go-bindata && \

--- a/auth_server/gen_version.py
+++ b/auth_server/gen_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import datetime
 import sys


### PR DESCRIPTION
This fixes the `build-release` target. The builder image is based on alpine, which as of 3.12 no longer includes `py2-pip`.