### PR TITLE
Add Github actions for go tests

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -1,0 +1,30 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install deps
+      run: |
+        python -m pip install --upgrade pip
+        pip install GitPython
+        cd auth_server
+        python gen_version.py
+    - name: Test
+      run: |
+        cd auth_server
+        go test ./...
+    - name: Build
+      run: |
+        cd auth_server
+        make


### PR DESCRIPTION
As promised go tests are now run by Github Actions

Future enhancements could include linting.