### PR TITLE
Install go-binddata as a global binary

### DIFF
--- a/auth_server/Makefile
+++ b/auth_server/Makefile
@@ -33,7 +33,7 @@ build-release: ca-certificates.crt
 	    apk update && apk add git make py3-pip && pip install GitPython && \
 	    cd /src/auth_server && \
 	    umask 0 && \
-	    go install -v github.com/go-bindata/go-bindata && \
+	    go get -u github.com/go-bindata/go-bindata/... && \
 	    make generate && \
 	    CGO_ENABLED=0 go build -v --ldflags=--s"
 	@echo === Built version $$(cat version.txt) ===


### PR DESCRIPTION
Hi,
I tried to run the build-release target but I was not successful. The image stopped with an error:

```
authn/authn.go:19: running "go-bindata": exec: "go-bindata": executable file not found in $PATH

make: *** [Makefile:17: generate] Error 1
```

With this PR, the go-binddata tool is installed as described in [https://github.com/go-bindata/go-bindata#installation](https://github.com/go-bindata/go-bindata#installation).