### PR TITLE
Update README.md

### DIFF
--- a/chart/docker-auth/README.md
+++ b/chart/docker-auth/README.md
@@ -206,6 +206,7 @@ docker-registry:
       kubernetes.io/ingress.class: "nginx"
       nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    path: /
     tls:
       - hosts:
           - $DOCKER_REG_HOSTNAME
@@ -225,6 +226,7 @@ docker-registry:
 
 ingress:
   enabled: true
+  path: /
   hosts:
     - $DOCKER_AUTH_HOSTNAME
   annotations:


### PR DESCRIPTION
Ensure path is set to avoid ingress is generated with empty path. For search reference, this is the error I received

```sh
Error: UPGRADE FAILED: failed to create resource: Ingress.extensions "docker-registry-docker-auth" is invalid: spec.rules[0].http.paths[0].path: Invalid value: "": must be an absolute path
```

This probably should be handled at https://github.com/cesanta/docker_auth/blob/main/chart/docker-auth/templates/ingress.yaml#L4 setting a sensible default

Thanks!