### PR TITLE
Fix regexp parsing IPv6 without port indication in remote_addr

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	hostPortRegex = regexp.MustCompile(`\[?(.+?)\]?:\d+$`)
+	hostPortRegex = regexp.MustCompile(`^(?:\[(.+)\]:\d+|([^:]+):\d+)$`)
 	scopeRegex    = regexp.MustCompile(`([a-z0-9]+)(\([a-z0-9]+\))?`)
 )
 
@@ -182,7 +182,11 @@ func (ar authRequest) String() string {
 func parseRemoteAddr(ra string) net.IP {
 	hp := hostPortRegex.FindStringSubmatch(ra)
 	if hp != nil {
-		ra = string(hp[1])
+		if hp[1] != "" {
+			ra = hp[1]
+		} else if hp[2] != "" {
+			ra = hp[2]
+		}
 	}
 	res := net.ParseIP(ra)
 	return res


### PR DESCRIPTION
Hi!

Thanks for your awesome project!

I tried to use this project in an IPv6 infra, behind a reverse proxy and I got the following response from the auth server:

```
Bad request: unable to parse remote addr 2a01:x:x:x:x:x:x:x
```

Leading to:

```
$ docker pull registry.example.com/hello-world
Using default tag: latest
Error response from daemon: Head "https://registry.example.com/v2/hello-world/manifests/latest": error parsing HTTP 400 response body: invalid character 'B' looking for beginning of value: "Bad request: unable to parse remote addr 2a01:x:x:x:x:x:x:x\n"
```

My nginx configured that way:

```
proxy_pass          http://127.0.0.1:5001;
proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
```

And my YAML looking like this:

```yaml
server:
    real_ip_header: "X-Forwarded-For"
```

I fix through this PR, the regexp that cause the trouble. In fact, the regexp intended to pick `2a01:cafe:cafe::beef` from `[2a01:cafe:cafe::beef]:4242` was also activated by every single IPv6 without port indication (as `[` and `]` was optional), leading to invalid IPv6: because `2a01:cafe:cafe::beef` was replaced by `2a01:cafe:cafe:` and so on.

By requiring `[` and `]` to not be optional, if the text doesn't match the regexp, no replacement is made, the IPv6 is then kept valid.