### PR TITLE
Support Unix Domain Sockets

### DIFF
--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -56,6 +56,7 @@ type Config struct {
 
 type ServerConfig struct {
 	ListenAddress       string            `yaml:"addr,omitempty"`
+	Net                 string            `yaml:"net,omitempty"`
 	PathPrefix          string            `yaml:"path_prefix,omitempty"`
 	RealIPHeader        string            `yaml:"real_ip_header,omitempty"`
 	RealIPPos           int               `yaml:"real_ip_pos,omitempty"`
@@ -149,6 +150,13 @@ var TLSCurveIDValues = map[string]tls.CurveID{
 func validate(c *Config) error {
 	if c.Server.ListenAddress == "" {
 		return errors.New("server.addr is required")
+	}
+	if c.Server.Net != "unix" && c.Server.Net != "tcp" {
+		if c.Server.Net == "" {
+			c.Server.Net = "tcp"
+		} else {
+			return errors.New("server.net must be unix or tcp")
+		}
 	}
 	if c.Server.PathPrefix != "" && !strings.HasPrefix(c.Server.PathPrefix, "/") {
 		return errors.New("server.path_prefix must be an absolute path")

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -12,7 +12,11 @@
 
 server:  # Server settings.
   # Address to listen on.
+  # Can be HOST:PORT for TCP or file path (e.g. /run/docker_auth.sock) for Unix socket.
   addr: ":5001"
+
+  # Network, can be "tcp" or "unix" ("tcp" if unspecified).
+  net: "tcp"
 
   # URL path prefix to use.
   path_prefix: ""


### PR DESCRIPTION
Similar to Docker Registry, use combination of `addr` and `net` (supporting values `tcp` and `unix`). 
Requires #325