### PR TITLE
Support auth via certificates and headers

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -263,6 +263,24 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 			ar.Password = api.PasswordString(password)
 		}
 	}
+
+	if as.config.AlternateCredentials != nil {
+		var altCredsSuccess bool
+		username := alternateCredentials(req, as.config.AlternateCredentials.Username)
+		password := alternateCredentials(req, as.config.AlternateCredentials.Password)
+		if username != "" && password != "" && username == ar.User {
+			ar.User = username
+			ar.Password = api.PasswordString(password)
+			altCredsSuccess = true
+		}
+		if altCredsSuccess && as.config.AlternateCredentials.Label != "" {
+			if ar.Labels == nil {
+				ar.Labels = make(api.Labels, 1)
+			}
+			ar.Labels[as.config.AlternateCredentials.Label] = []string{fmt.Sprint(altCredsSuccess)}
+		}
+	}
+
 	ar.Account = req.FormValue("account")
 	if ar.Account == "" {
 		ar.Account = ar.User
@@ -272,6 +290,16 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 	ar.Service = req.FormValue("service")
 	if err := req.ParseForm(); err != nil {
 		return nil, fmt.Errorf("invalid form value")
+	}
+
+	if as.config.ClientCertLabels != "" && req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
+		if ar.Labels == nil {
+			ar.Labels = make(api.Labels, 3)
+		}
+		clientCert := req.TLS.PeerCertificates[0]
+		ar.Labels[as.config.ClientCertLabels+"_O"] = clientCert.Subject.Organization
+		ar.Labels[as.config.ClientCertLabels+"_OU"] = clientCert.Subject.OrganizationalUnit
+		ar.Labels[as.config.ClientCertLabels+"_DNS_NAMES"] = clientCert.DNSNames
 	}
 	// https://github.com/docker/distribution/blob/1b9ab303a477ded9bdd3fc97e9119fa8f9e58fca/docs/spec/auth/scope.md#resource-scope-grammar
 	if req.FormValue("scope") != "" {
@@ -311,6 +339,19 @@ func (as *AuthServer) ParseRequest(req *http.Request) (*authRequest, error) {
 	return ar, nil
 }
 
+func alternateCredentials(r *http.Request, config *CredentialSourceConfig) string {
+	switch config.Source {
+	case sourceHeader:
+		return r.Header.Get(config.Value)
+	case sourceStatic:
+		return config.Value
+	case sourceCN:
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			return r.TLS.PeerCertificates[0].Subject.CommonName
+		}
+	}
+	return ""
+}
 func (as *AuthServer) Authenticate(ar *authRequest) (bool, api.Labels, error) {
 	for i, a := range as.authenticators {
 		result, labels, err := a.Authenticate(ar.Account, ar.Password)
@@ -498,7 +539,7 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 			http.Error(rw, "Auth failed.", http.StatusUnauthorized)
 			return
 		}
-		ar.Labels = labels
+		ar.Labels = mergeLabels(ar.Labels, labels)
 	}
 	if len(ar.Scopes) > 0 {
 		ares, err = as.Authorize(ar)
@@ -524,6 +565,18 @@ func (as *AuthServer) doAuth(rw http.ResponseWriter, req *http.Request) {
 	glog.V(3).Infof("%s", result)
 	rw.Header().Set("Content-Type", "application/json")
 	rw.Write(result)
+}
+
+func mergeLabels(dest api.Labels, src api.Labels) api.Labels {
+	if dest == nil {
+		return src
+	} else if src == nil {
+		return dest
+	}
+	for k, v := range src {
+		dest[k] = v
+	}
+	return dest
 }
 
 func (as *AuthServer) Stop() {

--- a/examples/client_certificates.yml
+++ b/examples/client_certificates.yml
@@ -1,0 +1,43 @@
+---
+server:
+  addr: :5001
+  certificate: /path/to/server.pem
+  key: /path/to/server.key
+  client_ca: /path/to/ca.crt
+  client_auth_type: RequireAndVerifyClientCert
+
+alternate_credentials:
+  # Add a label indicating if alternate credentials were used.
+  label: ALTERNATE_CREDENTIALS
+  username:
+    source: cn
+  password:
+    source: static
+    # a "sentinel value for use with static auth
+    value: secret
+
+users:
+  user1:
+    # the hash of "secret"
+    password: $2y$05$hS3s0Fbh5EMclimhNeCyEeH9VIynngvgDmGO6MbooXxle7S0D5boK
+
+# Add TLS_* labels
+client_cert_labels: TLS
+
+acl:
+  - match: {account: "user1"}
+    actions: ["*"]
+    comment: User 1 has full access
+  # We can also require that alternate credentials be used through a label match:
+  - match: {account: "user1", labels: {ALTERNATE_CREDENTIALS: "true"}}
+    actions: ["*"]
+    comment: User 1 has full access
+  - match: {labels: {TLS_OU: developers}}
+    actions: ["pull"]
+    comment: Users whose certificate has the OU "developers" can pull
+
+# To login with a client certificate:
+#
+# 1. Configure Docker to use the certificate: https://docs.docker.com/engine/security/certificates/
+# 2. Run docker login. The username must be the same as the certificate CN (or header).
+#    The password can be anything.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -26,6 +26,11 @@ server:  # Server settings.
   # Use specific certificate and key.
   certificate: "/path/to/server.pem"
   key: "/path/to/server.key"
+  # Optional CA file for client certificate verification.
+  client_ca: /path/to/ca.crt
+  # Optional. Defaults to NoClientCert
+  # Values can be found at  https://pkg.go.dev/crypto/tls#ClientAuthType
+  client_auth_type: NoClientCert
   #
   # The following optional settings will fine tune TLS configuration to improve security.
   # Leaving them unset should be just fine for most installations.
@@ -446,3 +451,30 @@ ext_authz:
 plugin_authz:
   plugin_path: ""
 
+# If not empty, and a clinet certificate is present, the following
+# lables will be added prefixed with the given value:
+#   - <prefix>_O = <certificate O(s)>
+#   - <prefix>_OU = <certificate OU(s)>
+#   - <prefix>_DNS_NAMES = <certificate DNS SAN(s)>
+client_cert_labels: TLS
+
+# Populate the username/password from the HTTP request
+alternate_credentials:
+  # If not empty, a label with the given name and single value "true" or "false" is added
+  # indicating whether or not alternate credentials was used.
+  label: ALTERNATE_CREDENTIALS
+  username:
+    # Required
+    # Choices:
+    #   cn - Client certificate CN.
+    #   header - Value of header specified in `value`.
+    #   static - The static value in `value`.
+    source: header
+    # Required if source is static or header.
+    value: X-Forwarded-User
+  # See above for configuration values
+  password:
+    # Required
+    source:
+    # Required
+    value:

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -28,8 +28,8 @@ server:  # Server settings.
   key: "/path/to/server.key"
   # Optional CA file for client certificate verification.
   client_ca: /path/to/ca.crt
-  # Optional. Defaults to NoClientCert
-  # Values can be found at  https://pkg.go.dev/crypto/tls#ClientAuthType
+  # Optional. Defaults to NoClientCert.
+  # Values can be found at https://pkg.go.dev/crypto/tls#ClientAuthType
   client_auth_type: NoClientCert
   #
   # The following optional settings will fine tune TLS configuration to improve security.
@@ -451,8 +451,8 @@ ext_authz:
 plugin_authz:
   plugin_path: ""
 
-# If not empty, and a clinet certificate is present, the following
-# lables will be added prefixed with the given value:
+# If not empty, and a client certificate is present, the following
+# lables prefixed with the given value, will be added:
 #   - <prefix>_O = <certificate O(s)>
 #   - <prefix>_OU = <certificate OU(s)>
 #   - <prefix>_DNS_NAMES = <certificate DNS SAN(s)>
@@ -467,12 +467,12 @@ alternate_credentials:
     # Required
     # Choices:
     #   cn - Client certificate CN.
-    #   header - Value of header specified in `value`.
+    #   header - The value of the header specified in `value`.
     #   static - The static value in `value`.
     source: header
-    # Required if source is static or header.
+    # Required if `source`` is static or header.
     value: X-Forwarded-User
-  # See above for configuration values
+  # See above for configuration values.
   password:
     # Required
     source:


### PR DESCRIPTION
This PR adds support for authentication via a client certificate (#300) or via a header set by a reverse proxy.

In order to use a client certificate (or auth by header), the username passed to `docker login` must match that of the certificate's CN or the value in the header used for authentication. The password doesn't matter. I've added an example to show how I'm using it in the `examples` folder.