### PR TITLE
Add more configuration options for OIDC auth

### DIFF
--- a/auth_server/authn/data/oidc_auth.tmpl
+++ b/auth_server/authn/data/oidc_auth.tmpl
@@ -9,7 +9,7 @@
 <body>
   <div id="panel">
     <p>
-      <a id="login-with-oidc" href="{{.AuthEndpoint}}?response_type=code&scope=openid%20email&client_id={{.ClientId}}&redirect_uri={{.RedirectURI}}">
+      <a id="login-with-oidc" href="{{.AuthEndpoint}}?response_type=code&scope={{.Scope}}&client_id={{.ClientId}}&redirect_uri={{.RedirectURI}}">
         Login with OIDC Provider
       </a>
     </p>

--- a/auth_server/authn/oidc_auth.go
+++ b/auth_server/authn/oidc_auth.go
@@ -145,11 +145,12 @@ Executes tmpl for the OIDC login page.
 */
 func (ga *OIDCAuth) doOIDCAuthPage(rw http.ResponseWriter) {
 	if err := ga.tmpl.Execute(rw, struct {
-		AuthEndpoint, RedirectURI, ClientId string
+		AuthEndpoint, RedirectURI, ClientId, Scope string
 	}{
 		AuthEndpoint: ga.provider.Endpoint().AuthURL,
 		RedirectURI:  ga.oauth.RedirectURL,
 		ClientId:     ga.oauth.ClientID,
+		Scope:        strings.Join(ga.config.Scopes, " "),
 	}); err != nil {
 		http.Error(rw, fmt.Sprintf("Template error: %s", err), http.StatusInternalServerError)
 	}

--- a/auth_server/authn/oidc_auth.go
+++ b/auth_server/authn/oidc_auth.go
@@ -59,6 +59,8 @@ type OIDCAuthConfig struct {
 	// --- optional ---
 	// []string to add as labels.
 	LabelsClaims []string `yaml:"labels_claims,omitempty"`
+	// --- optional ---
+	Scopes []string `yaml:"scopes,omitempty"`
 }
 
 // OIDCRefreshTokenResponse is sent by OIDC provider in response to the grant_type=refresh_token request.
@@ -108,7 +110,7 @@ func NewOIDCAuth(c *OIDCAuthConfig) (*OIDCAuth, error) {
 		ClientSecret: c.ClientSecret,
 		Endpoint:     prov.Endpoint(),
 		RedirectURL:  c.RedirectURL,
-		Scopes:       []string{oidc.ScopeOpenID, "email"},
+		Scopes:       c.Scopes,
 	}
 	return &OIDCAuth{
 		config:     c,

--- a/auth_server/authn/oidc_auth.go
+++ b/auth_server/authn/oidc_auth.go
@@ -359,7 +359,15 @@ func (ga *OIDCAuth) Authenticate(user string, password api.PasswordString) (bool
 	} else if err != nil {
 		return false, nil, err
 	}
-	return true, nil, nil
+
+	v, err := ga.db.GetValue(user)
+	if err != nil || v == nil {
+		if err == nil {
+			err = errors.New("no db value, please sign out and sign in again")
+		}
+		return false, nil, err
+	}
+	return true, v.Labels, err
 }
 
 func (ga *OIDCAuth) Stop() {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -243,6 +243,9 @@ func validate(c *Config) error {
 		if oidc.UserClaim == "" {
 			oidc.UserClaim = "email"
 		}
+		if oidc.Scopes == nil {
+			oidc.Scopes = []string{"openid", "email"}
+		}
 	}
 	if glab := c.GitlabAuth; glab != nil {
 		if glab.ClientSecretFile != "" {

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -240,6 +240,9 @@ func validate(c *Config) error {
 		if oidc.HTTPTimeout <= 0 {
 			oidc.HTTPTimeout = 10
 		}
+		if oidc.UserClaim == "" {
+			oidc.UserClaim = "email"
+		}
 	}
 	if glab := c.GitlabAuth; glab != nil {
 		if glab.ClientSecretFile != "" {

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -193,6 +193,11 @@ oidc_auth:
   # String array claims that will be used as labels.
   label_claims:
     - groups
+  # Default: [openid, email]
+  scopes:
+    - openid
+    - email
+
 
 # Gitlab authentication.
 # ==! NB: DO NOT ENTER YOUR Gitlab PASSWORD AT "docker login". IT WILL NOT WORK.

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -187,6 +187,12 @@ oidc_auth:
   http_timeout: 10
   # the url of the registry where you want to login. Is used to present the full docker login command.
   registry_url: "url_of_my_beautiful_docker_registry"
+  # The claim to use for the username.
+  # Default: email
+  user_claim: email
+  # String array claims that will be used as labels.
+  label_claims:
+    - groups
 
 # Gitlab authentication.
 # ==! NB: DO NOT ENTER YOUR Gitlab PASSWORD AT "docker login". IT WILL NOT WORK.


### PR DESCRIPTION
This PR adds the following features to OIDC auth:

- Configurable scope
- Labels from claims
- Configurable username claim

I've made the defaults the old static values so there shouldn't be any incompatibilities.