### PR TITLE
Adding Support for Power (ppc64le) platform.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           context: auth_server
           file: auth_server/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           build-args: |


### PR DESCRIPTION
I am raising this PR to provide  cesanta /docker_auth  image for **Power** (ppc64le) platform.I have modified the GitHub Action workflow to cross compile docker image for ppc64le.I have tested the workflows in my fork repository and mentioned below are the links for the same:

For `docker.yml` workflow:
1. Link for GitHub Actions : https://github.com/Sunidhi-Gaonkar1/docker_auth/actions/runs/2880757063
2. Link for the image : https://github.com/Sunidhi-Gaonkar1/docker_auth/pkgs/container/cesanta%2Fdocker_auth