### PR TITLE
Add option to adjust bcrypt hashing cost

### DIFF
--- a/auth_server/authn/gitlab_auth.go
+++ b/auth_server/authn/gitlab_auth.go
@@ -56,20 +56,20 @@ type ParentGitlabTeam struct {
 }
 
 type GitlabAuthConfig struct {
-	Organization     string            `yaml:"organization,omitempty"`
-	ClientId         string            `yaml:"client_id,omitempty"`
-	ClientSecret     string            `yaml:"client_secret,omitempty"`
-	ClientSecretFile string            `yaml:"client_secret_file,omitempty"`
-	TokenDB          string            `yaml:"token_db,omitempty"`
-	GCSTokenDB       *GCSStoreConfig   `yaml:"gcs_token_db,omitempty"`
-	RedisTokenDB     *RedisStoreConfig `yaml:"redis_token_db,omitempty"`
-	HTTPTimeout      time.Duration     `yaml:"http_timeout,omitempty"`
-	RevalidateAfter  time.Duration     `yaml:"revalidate_after,omitempty"`
-	GitlabWebUri     string            `yaml:"gitlab_web_uri,omitempty"`
-	GitlabApiUri     string            `yaml:"gitlab_api_uri,omitempty"`
-	RegistryUrl      string            `yaml:"registry_url,omitempty"`
-	GrantType        string            `yaml:"grant_type,omitempty"`
-	RedirectUri      string            `yaml:"redirect_uri,omitempty"`
+	Organization     string              `yaml:"organization,omitempty"`
+	ClientId         string              `yaml:"client_id,omitempty"`
+	ClientSecret     string              `yaml:"client_secret,omitempty"`
+	ClientSecretFile string              `yaml:"client_secret_file,omitempty"`
+	LevelTokenDB     *LevelDBStoreConfig `yaml:"level_token_db,omitempty"`
+	GCSTokenDB       *GCSStoreConfig     `yaml:"gcs_token_db,omitempty"`
+	RedisTokenDB     *RedisStoreConfig   `yaml:"redis_token_db,omitempty"`
+	HTTPTimeout      time.Duration       `yaml:"http_timeout,omitempty"`
+	RevalidateAfter  time.Duration       `yaml:"revalidate_after,omitempty"`
+	GitlabWebUri     string              `yaml:"gitlab_web_uri,omitempty"`
+	GitlabApiUri     string              `yaml:"gitlab_api_uri,omitempty"`
+	RegistryUrl      string              `yaml:"registry_url,omitempty"`
+	GrantType        string              `yaml:"grant_type,omitempty"`
+	RedirectUri      string              `yaml:"redirect_uri,omitempty"`
 }
 
 type CodeToGitlabTokenResponse struct {
@@ -107,17 +107,18 @@ type GitlabAuth struct {
 func NewGitlabAuth(c *GitlabAuthConfig) (*GitlabAuth, error) {
 	var db TokenDB
 	var err error
-	dbName := c.TokenDB
+	var dbName string
 
 	switch {
 	case c.GCSTokenDB != nil:
-		db, err = NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
+		db, err = NewGCSTokenDB(c.GCSTokenDB)
 		dbName = "GCS: " + c.GCSTokenDB.Bucket
 	case c.RedisTokenDB != nil:
 		db, err = NewRedisTokenDB(c.RedisTokenDB)
 		dbName = db.(*redisTokenDB).String()
 	default:
-		db, err = NewTokenDB(c.TokenDB)
+		db, err = NewTokenDB(c.LevelTokenDB)
+		dbName = c.LevelTokenDB.Path
 	}
 
 	if err != nil {

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -33,14 +33,14 @@ import (
 )
 
 type GoogleAuthConfig struct {
-	Domain           string            `yaml:"domain,omitempty"`
-	ClientId         string            `yaml:"client_id,omitempty"`
-	ClientSecret     string            `yaml:"client_secret,omitempty"`
-	ClientSecretFile string            `yaml:"client_secret_file,omitempty"`
-	TokenDB          string            `yaml:"token_db,omitempty"`
-	GCSTokenDB       *GCSStoreConfig   `yaml:"gcs_token_db,omitempty"`
-	RedisTokenDB     *RedisStoreConfig `yaml:"redis_token_db,omitempty"`
-	HTTPTimeout      time.Duration     `yaml:"http_timeout,omitempty"`
+	Domain           string              `yaml:"domain,omitempty"`
+	ClientId         string              `yaml:"client_id,omitempty"`
+	ClientSecret     string              `yaml:"client_secret,omitempty"`
+	ClientSecretFile string              `yaml:"client_secret_file,omitempty"`
+	LevelTokenDB     *LevelDBStoreConfig `yaml:"level_token_db,omitempty"`
+	GCSTokenDB       *GCSStoreConfig     `yaml:"gcs_token_db,omitempty"`
+	RedisTokenDB     *RedisStoreConfig   `yaml:"redis_token_db,omitempty"`
+	HTTPTimeout      time.Duration       `yaml:"http_timeout,omitempty"`
 }
 
 type GoogleAuthRequest struct {
@@ -131,17 +131,18 @@ type GoogleAuth struct {
 func NewGoogleAuth(c *GoogleAuthConfig) (*GoogleAuth, error) {
 	var db TokenDB
 	var err error
-	dbName := c.TokenDB
+	var dbName string
 
 	switch {
 	case c.GCSTokenDB != nil:
-		db, err = NewGCSTokenDB(c.GCSTokenDB.Bucket, c.GCSTokenDB.ClientSecretFile)
+		db, err = NewGCSTokenDB(c.GCSTokenDB)
 		dbName = "GCS: " + c.GCSTokenDB.Bucket
 	case c.RedisTokenDB != nil:
 		db, err = NewRedisTokenDB(c.RedisTokenDB)
 		dbName = db.(*redisTokenDB).String()
 	default:
-		db, err = NewTokenDB(c.TokenDB)
+		db, err = NewTokenDB(c.LevelTokenDB)
+		dbName = c.LevelTokenDB.Path
 	}
 	if err != nil {
 		return nil, err

--- a/auth_server/authn/tokendb_gcs.go
+++ b/auth_server/authn/tokendb_gcs.go
@@ -34,20 +34,26 @@ import (
 type GCSStoreConfig struct {
 	Bucket           string `yaml:"bucket,omitempty"`
 	ClientSecretFile string `yaml:"client_secret_file,omitempty"`
+	TokenHashCost    int    `yaml:"token_hash_cost,omitempty"`
 }
 
 // NewGCSTokenDB return a new TokenDB structure which uses Google Cloud Storage as backend. The
 // created DB uses file-per-user strategy and stores credentials independently for each user.
 //
 // Note: it's not recomanded bucket to be shared with other apps or services
-func NewGCSTokenDB(bucket, clientSecretFile string) (TokenDB, error) {
-	gcs, err := storage.NewClient(context.Background(), option.WithServiceAccountFile(clientSecretFile))
-	return &gcsTokenDB{gcs, bucket}, err
+func NewGCSTokenDB(options *GCSStoreConfig) (TokenDB, error) {
+	gcs, err := storage.NewClient(context.Background(), option.WithServiceAccountFile(options.ClientSecretFile))
+	tokenHashCost := options.TokenHashCost
+	if tokenHashCost <= 0 {
+		tokenHashCost = bcrypt.DefaultCost
+	}
+	return &gcsTokenDB{gcs, options.Bucket, tokenHashCost}, err
 }
 
 type gcsTokenDB struct {
 	gcs    *storage.Client
 	bucket string
+	tokenHashCost int
 }
 
 // GetValue gets token value associated with the provided user. Each user
@@ -77,7 +83,7 @@ func (db *gcsTokenDB) GetValue(user string) (*TokenDBValue, error) {
 func (db *gcsTokenDB) StoreToken(user string, v *TokenDBValue, updatePassword bool) (dp string, err error) {
 	if updatePassword {
 		dp = uniuri.New()
-		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), bcrypt.DefaultCost)
+		dph, _ := bcrypt.GenerateFromPassword([]byte(dp), db.tokenHashCost)
 		v.DockerPassword = string(dph)
 	}
 

--- a/auth_server/authn/tokendb_level.go
+++ b/auth_server/authn/tokendb_level.go
@@ -36,6 +36,11 @@ const (
 
 var ExpiredToken = errors.New("expired token")
 
+type LevelDBStoreConfig struct {
+	Path           string `yaml:"path,omitempty"`
+	TokenHashCost  int    `yaml:"token_hash_cost,omitempty"`
+}
+
 // TokenDB stores tokens using LevelDB
 type TokenDB interface {
 	// GetValue takes a username returns the corresponding token
@@ -75,8 +80,12 @@ type TokenDBValue struct {
 }
 
 // NewTokenDB returns a new TokenDB structure
-func NewTokenDB(file string) (TokenDB, error) {
-	db, err := leveldb.OpenFile(file, nil)
+func NewTokenDB(options *LevelDBStoreConfig) (TokenDB, error) {
+	db, err := leveldb.OpenFile(options.Path, nil)
+	tokenHashCost := options.TokenHashCost
+	if tokenHashCost <= 0 {
+		tokenHashCost = bcrypt.DefaultCost
+	}
 	return &TokenDBImpl{
 		DB: db,
 	}, err

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -193,7 +193,7 @@ func validate(c *Config) error {
 			}
 			gac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.TokenDB == "" && (gac.GCSTokenDB == nil && gac.RedisTokenDB == nil)) {
+		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.LevelTokenDB != nil && (gac.GCSTokenDB == nil && gac.RedisTokenDB == nil)) {
 			return errors.New("google_auth.{client_id,client_secret,token_db} are required")
 		}
 
@@ -217,7 +217,7 @@ func validate(c *Config) error {
 			}
 			ghac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.TokenDB == "" && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.LevelTokenDB != nil && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
 			return errors.New("github_auth.{client_id,client_secret,token_db} are required")
 		}
 
@@ -245,7 +245,7 @@ func validate(c *Config) error {
 			}
 			oidc.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.TokenDB == "" && (oidc.GCSTokenDB == nil && oidc.RedisTokenDB == nil)) {
+		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.LevelTokenDB != nil && (oidc.GCSTokenDB == nil && oidc.RedisTokenDB == nil)) {
 			return errors.New("oidc_auth.{issuer,redirect_url,client_id,client_secret,token_db} are required")
 		}
 
@@ -275,7 +275,7 @@ func validate(c *Config) error {
 			}
 			glab.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.TokenDB == "" && (glab.GCSTokenDB == nil && glab.RedisTokenDB == nil)) {
+		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.LevelTokenDB != nil && (glab.GCSTokenDB == nil && glab.RedisTokenDB == nil)) {
 			return errors.New("gitlab_auth.{client_id,client_secret,token_db} are required")
 		}
 


### PR DESCRIPTION
The default bcrypt hashing cost can be quite problematic when serving many requests at once. Depending on token expiration times and other security considerations, lowering the cost can be a valid fix. This PR adds the `token_hash_cost` to all TokenDB configs (redis, GCS, LevelDB). Note that the level db config was a simple string previously, I had to change it to a struct with `{path: string, token_hash_cost: int}`.

Note that this PR is built on top of #374.