### PR TITLE
Use secure cipher suites for tls by default

### DIFF
--- a/auth_server/main.go
+++ b/auth_server/main.go
@@ -64,9 +64,7 @@ func ServeOnce(c *server.Config, cf string) (*server.AuthServer, *http.Server) {
 		glog.Exitf("Failed to create auth server: %s", err)
 	}
 
-	tlsConfig := &tls.Config{
-		PreferServerCipherSuites: true,
-	}
+	tlsConfig := &tls.Config{}
 	if c.Server.HSTS {
 		glog.Info("HTTP Strict Transport Security enabled")
 	}
@@ -101,6 +99,10 @@ func ServeOnce(c *server.Config, cf string) (*server.AuthServer, *http.Server) {
 		}
 		tlsConfig.CipherSuites = values
 		glog.Infof("TLS CipherSuites: %s", c.Server.TLSCipherSuites)
+	} else {
+		for _, s := range tls.CipherSuites() {
+			tlsConfig.CipherSuites = append(tlsConfig.CipherSuites, s.ID)
+		}
 	}
 	if c.Server.CertFile != "" || c.Server.KeyFile != "" {
 		// Check for partial configuration.


### PR DESCRIPTION
Fixes https://github.com/cesanta/docker_auth/issues/379

Tested with `docker run --rm -ti  drwetter/testssl.sh -e --std 10.3.68.72:5001`

![image](https://github.com/cesanta/docker_auth/assets/6214067/0b18a3fb-38f8-4314-895b-886007b42883)
