### PR TITLE
Fix breaking changes changes made in 1.12 and leftovers

### DIFF
--- a/auth_server/authn/github_auth.go
+++ b/auth_server/authn/github_auth.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -117,7 +117,6 @@ func execGHExperimentalApiRequest(url string, token string) (*http.Response, err
 }
 
 // removeSubstringsFromString removes all occurences of stringsToStrip from sourceStr
-//
 func removeSubstringsFromString(sourceStr string, stringsToStrip []string) string {
 	theNewString := sourceStr
 	for _, i := range stringsToStrip {
@@ -129,7 +128,6 @@ func removeSubstringsFromString(sourceStr string, stringsToStrip []string) strin
 // parseLinkHeader parses the HTTP headers from the Github API response
 //
 // https://developer.github.com/v3/guides/traversing-with-pagination/
-//
 func parseLinkHeader(linkLines []string) (linkHeader, error) {
 	var lH linkHeader
 	// URL in link is enclosed in < >
@@ -255,7 +253,7 @@ func (gha *GitHubAuth) doGitHubAuthCreateToken(rw http.ResponseWriter, code stri
 		http.Error(rw, fmt.Sprintf("Error talking to GitHub auth backend: %s", err), http.StatusServiceUnavailable)
 		return
 	}
-	codeResp, _ := ioutil.ReadAll(resp.Body)
+	codeResp, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	glog.V(2).Infof("Code to token resp: %s", strings.Replace(string(codeResp), "\n", " ", -1))
 
@@ -317,7 +315,7 @@ func (gha *GitHubAuth) validateAccessToken(token string) (user string, err error
 		err = fmt.Errorf("could not verify token %s: %s", token, err)
 		return
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	var ti GitHubTokenUser
@@ -386,7 +384,7 @@ func (gha *GitHubAuth) fetchTeams(token string) ([]string, error) {
 		}
 
 		respHeaders := resp.Header
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 
 		err = json.Unmarshal(body, &pagedTeams)

--- a/auth_server/authn/google_auth.go
+++ b/auth_server/authn/google_auth.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -162,7 +162,7 @@ func (ga *GoogleAuth) DoGoogleAuth(rw http.ResponseWriter, req *http.Request) {
 		ga.doGoogleAuthPage(rw, req)
 		return
 	}
-	gauthRequest, _ := ioutil.ReadAll(req.Body)
+	gauthRequest, _ := io.ReadAll(req.Body)
 	glog.V(2).Infof("gauth request: %s", string(gauthRequest))
 	var gar GoogleAuthRequest
 	err := json.Unmarshal(gauthRequest, &gar)
@@ -203,7 +203,7 @@ func (ga *GoogleAuth) doGoogleAuthCreateToken(rw http.ResponseWriter, code strin
 		http.Error(rw, fmt.Sprintf("Error talking to Google auth backend: %s", err), http.StatusServiceUnavailable)
 		return
 	}
-	codeResp, _ := ioutil.ReadAll(resp.Body)
+	codeResp, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	glog.V(2).Infof("Code to token resp: %s", strings.Replace(string(codeResp), "\n", " ", -1))
 
@@ -262,7 +262,7 @@ func (ga *GoogleAuth) getIDTokenInfo(token string) (*GoogleTokenInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not verify token %s: %s", token, err)
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	resp.Body.Close()
 
 	var ti GoogleTokenInfo
@@ -317,7 +317,7 @@ func (ga *GoogleAuth) refreshAccessToken(refreshToken string) (rtr RefreshTokenR
 		err = fmt.Errorf("Error talking to Google auth backend: %s", err)
 		return
 	}
-	respStr, _ := ioutil.ReadAll(resp.Body)
+	respStr, _ := io.ReadAll(resp.Body)
 	glog.V(2).Infof("Refresh token resp: %s", strings.Replace(string(respStr), "\n", " ", -1))
 
 	err = json.Unmarshal(respStr, &rtr)
@@ -334,7 +334,7 @@ func (ga *GoogleAuth) validateAccessToken(toktype, token string) (user string, e
 	if err != nil {
 		return
 	}
-	respStr, _ := ioutil.ReadAll(resp.Body)
+	respStr, _ := io.ReadAll(resp.Body)
 	glog.V(2).Infof("Access token validation rrsponse: %s", strings.Replace(string(respStr), "\n", " ", -1))
 	var pr ProfileResponse
 	err = json.Unmarshal(respStr, &pr)

--- a/auth_server/authn/oidc_auth.go
+++ b/auth_server/authn/oidc_auth.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -40,29 +40,29 @@ import (
 type OIDCAuthConfig struct {
 	// --- necessary ---
 	// URL of the authentication provider. Must be able to serve the /.well-known/openid-configuration
-	Issuer           string            `yaml:"issuer,omitempty"`
+	Issuer string `yaml:"issuer,omitempty"`
 	// URL of the auth server. Has to end with /oidc_auth
-	RedirectURL      string            `yaml:"redirect_url,omitempty"`
+	RedirectURL string `yaml:"redirect_url,omitempty"`
 	// ID and secret, priovided by the OIDC provider after registration of the auth server
-	ClientId         string            `yaml:"client_id,omitempty"`
-	ClientSecret     string            `yaml:"client_secret,omitempty"`
-	ClientSecretFile string            `yaml:"client_secret_file,omitempty"`
+	ClientId         string `yaml:"client_id,omitempty"`
+	ClientSecret     string `yaml:"client_secret,omitempty"`
+	ClientSecretFile string `yaml:"client_secret_file,omitempty"`
 	// path where the tokendb should be stored within the container
-	LevelTokenDB     *LevelDBStoreConfig `yaml:"level_token_db,omitempty"`
-	GCSTokenDB       *GCSStoreConfig     `yaml:"gcs_token_db,omitempty"`
-	RedisTokenDB     *RedisStoreConfig   `yaml:"redis_token_db,omitempty"`
+	LevelTokenDB *LevelDBStoreConfig `yaml:"level_token_db,omitempty"`
+	GCSTokenDB   *GCSStoreConfig     `yaml:"gcs_token_db,omitempty"`
+	RedisTokenDB *RedisStoreConfig   `yaml:"redis_token_db,omitempty"`
 	// --- optional ---
-	HTTPTimeout      time.Duration     `yaml:"http_timeout,omitempty"`
+	HTTPTimeout time.Duration `yaml:"http_timeout,omitempty"`
 	// the URL of the docker registry. Used to generate a full docker login command after authentication
-	RegistryURL      string            `yaml:"registry_url,omitempty"`
+	RegistryURL string `yaml:"registry_url,omitempty"`
 	// --- optional ---
 	// String claim to use for the username
-	UserClaim        string            `yaml:"user_claim,omitempty"`
+	UserClaim string `yaml:"user_claim,omitempty"`
 	// --- optional ---
 	// []string to add as labels.
-	LabelsClaims     []string          `yaml:"labels_claims,omitempty"`
+	LabelsClaims []string `yaml:"labels_claims,omitempty"`
 	// --- optional ---
-	Scopes           []string          `yaml:"scopes,omitempty"`
+	Scopes []string `yaml:"scopes,omitempty"`
 }
 
 // OIDCRefreshTokenResponse is sent by OIDC provider in response to the grant_type=refresh_token request.
@@ -274,7 +274,7 @@ func (ga *OIDCAuth) refreshAccessToken(refreshToken string) (rtr OIDCRefreshToke
 		err = fmt.Errorf("error talking to OIDC auth backend: %s", err)
 		return
 	}
-	respStr, _ := ioutil.ReadAll(resp.Body)
+	respStr, _ := io.ReadAll(resp.Body)
 	glog.V(2).Infof("Refresh token resp: %s", strings.Replace(string(respStr), "\n", " ", -1))
 
 	err = json.Unmarshal(respStr, &rtr)

--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -70,7 +70,7 @@ type ServerConfig struct {
 
 	publicKey  libtrust.PublicKey
 	privateKey libtrust.PrivateKey
-	sigAlg string
+	sigAlg     string
 }
 
 type LetsEncryptConfig struct {
@@ -87,7 +87,7 @@ type TokenConfig struct {
 
 	publicKey  libtrust.PublicKey
 	privateKey libtrust.PrivateKey
-	sigAlg string
+	sigAlg     string
 }
 
 // TLSCipherSuitesValues maps CipherSuite names as strings to the actual values
@@ -193,8 +193,8 @@ func validate(c *Config) error {
 			}
 			gac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.LevelTokenDB != nil && (gac.GCSTokenDB == nil && gac.RedisTokenDB == nil)) {
-			return errors.New("google_auth.{client_id,client_secret,token_db} are required")
+		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.LevelTokenDB != nil && gac.LevelTokenDB.Path == "") {
+			return errors.New("google_auth.{client_id,client_secret,level_token_db.path} are required")
 		}
 
 		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.GCSTokenDB != nil && (gac.GCSTokenDB.Bucket == "" || gac.GCSTokenDB.ClientSecretFile == "")) {
@@ -217,8 +217,8 @@ func validate(c *Config) error {
 			}
 			ghac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.LevelTokenDB != nil && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
-			return errors.New("github_auth.{client_id,client_secret,token_db} are required")
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.LevelTokenDB != nil && ghac.LevelTokenDB.Path == "") {
+			return errors.New("github_auth.{client_id,client_secret,level_token_db.path} are required")
 		}
 
 		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.GCSTokenDB != nil && (ghac.GCSTokenDB.Bucket == "" || ghac.GCSTokenDB.ClientSecretFile == "")) {
@@ -245,8 +245,8 @@ func validate(c *Config) error {
 			}
 			oidc.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.LevelTokenDB != nil && (oidc.GCSTokenDB == nil && oidc.RedisTokenDB == nil)) {
-			return errors.New("oidc_auth.{issuer,redirect_url,client_id,client_secret,token_db} are required")
+		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.LevelTokenDB != nil && oidc.LevelTokenDB.Path == "") {
+			return errors.New("oidc_auth.{issuer,redirect_url,client_id,client_secret,level_token_db.path} are required")
 		}
 
 		if oidc.ClientId == "" || oidc.ClientSecret == "" || (oidc.GCSTokenDB != nil && (oidc.GCSTokenDB.Bucket == "" || oidc.GCSTokenDB.ClientSecretFile == "")) {
@@ -275,8 +275,8 @@ func validate(c *Config) error {
 			}
 			glab.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.LevelTokenDB != nil && (glab.GCSTokenDB == nil && glab.RedisTokenDB == nil)) {
-			return errors.New("gitlab_auth.{client_id,client_secret,token_db} are required")
+		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.LevelTokenDB != nil && glab.LevelTokenDB.Path == "") {
+			return errors.New("gitlab_auth.{client_id,client_secret,level_token_db.path} are required")
 		}
 
 		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.GCSTokenDB != nil && (glab.GCSTokenDB.Bucket == "" || glab.GCSTokenDB.ClientSecretFile == "")) {

--- a/docs/auth-methods.md
+++ b/docs/auth-methods.md
@@ -13,7 +13,8 @@ github_auth:
   organization: "my-org-name"
   client_id: "..."
   client_secret: "..." # or client_secret_file
-  token_db: /data/tokens.db
+  level_token_db:
+    path: /data/tokens.db
 ```
 
 Then specify what teams can do via acls

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -115,9 +115,10 @@ google_auth:
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
   # Where to store server tokens. Required.
-  token_db: "/somewhere/to/put/google_tokens.ldb"
+  level_token_db:
+    path: "/somewhere/to/put/google_tokens.ldb"
   # How long to wait when talking to Google servers. Optional.
-  http_timeout: 10
+  http_timeout: "10s"
 
 # GitHub authentication.
 # ==! NB: DO NOT ENTER YOUR GITHUB PASSWORD AT "docker login". IT WILL NOT WORK.
@@ -136,7 +137,8 @@ github_auth:
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
   # Either token_db file for storing of server tokens.
-  token_db: "/somewhere/to/put/github_tokens.ldb"
+  level_token_db:
+    path: "/somewhere/to/put/github_tokens.ldb"
   # or google cloud storage for storing of the sensitive information,
   gcs_token_db:
     bucket: "tokenBucket"
@@ -181,10 +183,11 @@ oidc_auth:
   # client_secret_file: "/path/to/client_secret.txt"
   #
   # a file in which the tokens should be stored. Does not have to exist, it will be generated in this case
-  token_db: "/path/to/tokens.ldb"
+  level_token_db:
+    path: "/path/to/tokens.ldb"
   # --- optional ---
   # How long to wait when talking to the OIDC provider.
-  http_timeout: 10
+  http_timeout: "10s"
   # the url of the registry where you want to login. Is used to present the full docker login command.
   registry_url: "url_of_my_beautiful_docker_registry"
   # The claim to use for the username.
@@ -211,7 +214,8 @@ gitlab_auth:
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
   # Either token_db file for storing of server tokens.
-  token_db: "/somewhere/to/put/gitlab_tokens.ldb"
+  level_token_db:
+    path: "/somewhere/to/put/gitlab_tokens.ldb"
   # or google cloud storage for storing of the sensitive information,
   gcs_token_db:
     bucket: "tokenBucket"


### PR DESCRIPTION
Fix breaking changes changes made in 1.12 and leftovers:

*  `http_timeout: 10` became `http_timeout: "10s"` in the samples, otherwise it will be nanoseconds and impossible to do Google auth etc. Nothing mentioned in the changelog.
*  `token_db` config string became `level_token_db.path` in the samples. Nothing mentioned in the changelog.
*  Fixed config options checks when  `level_token_db.path`  was set but docker_auth still complaining it is not.
* Replace deprecated ioutil.ReadAll > io.ReadAll