### PR TITLE
Add additional examples logins to results page

### DIFF
--- a/auth_server/authn/data/github_auth_result.tmpl
+++ b/auth_server/authn/data/github_auth_result.tmpl
@@ -43,9 +43,11 @@
 <body>
   <p class="message">
     You are successfully authenticated for the Docker Registry{{if .Organization}} with the <code>@{{.Organization}}</code> Github organization{{end}}.
-    Use the following username and password to login into the registry:
+    Log into the registry using one of these commands:
   </p>
   <hr>
   <pre class="command"><span>$ </span>docker login -u {{.Username}} -p {{.Password}} {{if .RegistryUrl}}{{.RegistryUrl}}{{else}}docker.example.com{{end}}</pre>
+  <pre class="command"><span>$ </span>podman login -u {{.Username}} -p {{.Password}} {{if .RegistryUrl}}{{.RegistryUrl}}{{else}}docker.example.com{{end}}</pre>
+  <pre class="command"><span>$ </span>nerdctl login -u {{.Username}} -p {{.Password}} {{if .RegistryUrl}}{{.RegistryUrl}}{{else}}docker.example.com{{end}}</pre>
 </body>
 </html>


### PR DESCRIPTION
Prior to this, there was not an easy copy/paste line for people not using Docker. This addes example lines that can be copy/pasted for those of us who use Podman / Podman Desktop and containerd's nerdctl.

For context, nerdctl is the default way of interacting with containers run within Lima (https://lima-vm.io) and is how I run x86 containers on an Apple Silicon Mac.