### PR TITLE
Fix LevelDB yaml unmarshall error and update documentation

### DIFF
--- a/auth_server/server/config.go
+++ b/auth_server/server/config.go
@@ -70,7 +70,7 @@ type ServerConfig struct {
 
 	publicKey  libtrust.PublicKey
 	privateKey libtrust.PrivateKey
-	sigAlg string
+	sigAlg     string
 }
 
 type LetsEncryptConfig struct {
@@ -87,7 +87,7 @@ type TokenConfig struct {
 
 	publicKey  libtrust.PublicKey
 	privateKey libtrust.PrivateKey
-	sigAlg string
+	sigAlg     string
 }
 
 // TLSCipherSuitesValues maps CipherSuite names as strings to the actual values
@@ -193,7 +193,7 @@ func validate(c *Config) error {
 			}
 			gac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.LevelTokenDB != nil && (gac.GCSTokenDB == nil && gac.RedisTokenDB == nil)) {
+		if gac.ClientId == "" || gac.ClientSecret == "" || (gac.LevelTokenDB == nil && (gac.GCSTokenDB == nil && gac.RedisTokenDB == nil)) {
 			return errors.New("google_auth.{client_id,client_secret,token_db} are required")
 		}
 
@@ -217,7 +217,7 @@ func validate(c *Config) error {
 			}
 			ghac.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.LevelTokenDB != nil && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
+		if ghac.ClientId == "" || ghac.ClientSecret == "" || (ghac.LevelTokenDB == nil && (ghac.GCSTokenDB == nil && ghac.RedisTokenDB == nil)) {
 			return errors.New("github_auth.{client_id,client_secret,token_db} are required")
 		}
 
@@ -245,7 +245,7 @@ func validate(c *Config) error {
 			}
 			oidc.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.LevelTokenDB != nil && (oidc.GCSTokenDB == nil && oidc.RedisTokenDB == nil)) {
+		if oidc.ClientId == "" || oidc.ClientSecret == "" || oidc.Issuer == "" || oidc.RedirectURL == "" || (oidc.LevelTokenDB == nil && (oidc.GCSTokenDB == nil && oidc.RedisTokenDB == nil)) {
 			return errors.New("oidc_auth.{issuer,redirect_url,client_id,client_secret,token_db} are required")
 		}
 
@@ -275,7 +275,7 @@ func validate(c *Config) error {
 			}
 			glab.ClientSecret = strings.TrimSpace(string(contents))
 		}
-		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.LevelTokenDB != nil && (glab.GCSTokenDB == nil && glab.RedisTokenDB == nil)) {
+		if glab.ClientId == "" || glab.ClientSecret == "" || (glab.LevelTokenDB == nil && (glab.GCSTokenDB == nil && glab.RedisTokenDB == nil)) {
 			return errors.New("gitlab_auth.{client_id,client_secret,token_db} are required")
 		}
 

--- a/docs/auth-methods.md
+++ b/docs/auth-methods.md
@@ -13,7 +13,10 @@ github_auth:
   organization: "my-org-name"
   client_id: "..."
   client_secret: "..." # or client_secret_file
-  token_db: /data/tokens.db
+  level_token_db:
+    path: /data/tokens.db
+    # Optional token hash cost for bcrypt hashing
+    # token_hash_cost: 5
 ```
 
 Then specify what teams can do via acls

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -115,7 +115,10 @@ google_auth:
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
   # Where to store server tokens. Required.
-  token_db: "/somewhere/to/put/google_tokens.ldb"
+  level_token_db:
+    path: "/somewhere/to/put/google_tokens.ldb"
+    # Optional token hash cost for bcrypt hashing
+    # token_hash_cost: 5
   # How long to wait when talking to Google servers. Optional.
   http_timeout: 10
 
@@ -135,8 +138,11 @@ github_auth:
   # want to have sensitive information checked in.
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
-  # Either token_db file for storing of server tokens.
-  token_db: "/somewhere/to/put/github_tokens.ldb"
+  # Either level_token_db file for storing of server tokens.
+  level_token_db: 
+    path: "/somewhere/to/put/github_tokens.ldb"
+    # Optional token hash cost for bcrypt hashing
+    # token_hash_cost: 5
   # or google cloud storage for storing of the sensitive information,
   gcs_token_db:
     bucket: "tokenBucket"
@@ -181,7 +187,10 @@ oidc_auth:
   # client_secret_file: "/path/to/client_secret.txt"
   #
   # a file in which the tokens should be stored. Does not have to exist, it will be generated in this case
-  token_db: "/path/to/tokens.ldb"
+  level_token_db: 
+    path: "/path/to/tokens.ldb"
+    # Optional token hash cost for bcrypt hashing
+    # token_hash_cost: 5
   # --- optional ---
   # How long to wait when talking to the OIDC provider.
   http_timeout: 10
@@ -210,8 +219,11 @@ gitlab_auth:
   # want to have sensitive information checked in.
   # client_secret: "verysecret"
   client_secret_file: "/path/to/client_secret.txt"
-  # Either token_db file for storing of server tokens.
-  token_db: "/somewhere/to/put/gitlab_tokens.ldb"
+  # Either level_token_db file for storing of server tokens.
+  level_token_db: 
+    path: "/somewhere/to/put/gitlab_tokens.ldb"
+    # Optional token hash cost for bcrypt hashing
+    # token_hash_cost: 5
   # or google cloud storage for storing of the sensitive information,
   gcs_token_db:
     bucket: "tokenBucket"


### PR DESCRIPTION
In order to ensure the project correctly validates authentication methods in the config file that can use a token db, this commit modifies the logic to ensure we check if all of the token methods are nil before outputting an error. Previously, if the local filesystem token db method was not nil and the other two (redis and google cloud storage) were nil, we would return an error and the config would be considered invalid.

Additionally, this commit documents the correct LevelDB settings for the config file. Prior to the addition of Bcrypt hashing cost, just using `token_db` was acceptable in the configuration along with a string representing the path. Given the swap to a struct instead of a string, we need to update documentation concerning this.