### PR TITLE
Add support for registry v3 JWK thumbprint key ID format

### DIFF
--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -381,7 +381,7 @@ func (as *AuthServer) CreateToken(ar *authRequest, ares []authzResult) (string, 
 	header := token.Header{
 		Type:       "JWT",
 		SigningAlg: tc.sigAlg,
-		KeyID:      tc.publicKey.KeyID(),
+		KeyID:      tc.keyID,
 	}
 	headerJSON, err := json.Marshal(header)
 	if err != nil {

--- a/examples/reference.yml
+++ b/examples/reference.yml
@@ -84,6 +84,11 @@ token:  # Settings for the tokens.
   # If not specified, server's TLS certificate and key are used.
   # certificate: "..."
   # key: "..."
+  # Whether the legacy libtrust key ID should be embedded in the `kid` header of the token.
+  # Set this to true if you are using registry v3, and to false if you are using registry v2.
+  # If set to true, the JWK thumbprint (see https://www.rfc-editor.org/rfc/rfc7638.html) of the certificate will be embedded instead.
+  # Defaults to false.
+  # disable_legacy_key_id: false
 
 # Authentication methods. All are tried, any one returning success is sufficient.
 # At least one must be configured. If you want an unauthenticated public setup,

--- a/examples/simple.yml
+++ b/examples/simple.yml
@@ -15,6 +15,8 @@ server:
 token:
   issuer: "Acme auth server"  # Must match issuer in the Registry config.
   expiration: 900
+  # Uncomment the following line if you are using registry v3, leave it commented if you are using registry v2
+  # disable_legacy_key_id: true
 
 users:
   # Password is specified as a BCrypt hash. Use `htpasswd -nB USERNAME` to generate.


### PR DESCRIPTION
Fixes https://github.com/cesanta/docker_auth/issues/386.
This is a fairly quick and dirty fix, feel free to burn this PR down :)

As mentioned in that issue, the v3 version of the registry no longer supports `libtrust` key IDs. There are multiple alternative options to choose from, but the simplest one to implement for this project is using the [JWK thumbprint](https://www.rfc-editor.org/rfc/rfc7638.html) of the public key as the key ID instead.

For every certificate present in the `rootcertbundle` passed to the registry, it'll add the public key to the trusted keys identified by the JWK thumbprint: https://github.com/distribution/distribution/blob/63d3892315c817c931b88779399a8e9142899a8e/registry/auth/token/accesscontroller.go#L346-L348
So, if you pass this JWK thumbprint in the key ID header in the token, the registry can select the proper signing key using this thumbprint.

This PR allows configuring this through a new directive in the configuration file, namely `token.disable_legacy_key_id`.
If set to true, it will pass the JWK thumbprint in the key ID header instead of the `libtrust` key ID. It defaults to false for now, to avoid accidental breakage when updating setups using the v2 registry.