### PR TITLE
Add disable_legacy_key_id to helm chart

### DIFF
--- a/chart/docker-auth/Chart.yaml
+++ b/chart/docker-auth/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "1.14.0"
 description: Docker Registry V2 authentication server
 name: docker-auth
-version: 1.14.0
+version: 1.14.1
 kubeVersion: ">=1.25"
 keywords:
 - docker

--- a/chart/docker-auth/README.md
+++ b/chart/docker-auth/README.md
@@ -57,6 +57,7 @@ helm uninstall docker-auth
 | **Authentication** | | |
 | `configmap.data.token.issuer` | Token issuer name (must match registry config) | `"Acme auth server"` |
 | `configmap.data.token.expiration` | Token expiration time in seconds | `900` |
+| `configmap.data.token.disableLegacyKeyId` | Disables legacy key IDs for registry v3 | `false` |
 | `configmap.data.users` | Static user definitions | See values.yaml |
 | `configmap.data.acl` | Access control list rules | See values.yaml |
 | **TLS/Certificates** | | |

--- a/chart/docker-auth/templates/configmap.yaml
+++ b/chart/docker-auth/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
       certificate: "/config/certs/server.pem"
       key: "/config/certs/server.key"
 {{- end }}
+{{- if .Values.configmap.data.token.disableLegacyKeyId }}
+      disable_legacy_key_id: {{ .Values.configmap.data.token.disableLegacyKeyId }}
+{{- end }}
     users:
       {{ .Values.configmap.data.users | toYaml | nindent 6 }}
     acl:

--- a/chart/docker-auth/values.yaml
+++ b/chart/docker-auth/values.yaml
@@ -25,6 +25,7 @@ configmap:
     token:
       issuer: "Acme auth server"
       expiration: 900
+      disableLegacyKeyId: false
     users:
       "admin":
         password: "$2y$05$LO.vzwpWC5LZGqThvEfznu8qhb5SGqvBSWY1J3yZ4AxtMRZ3kN5jC"  # password: badmin


### PR DESCRIPTION
Fixes #409
Follows on from #401 to add the changes for disable_legacy_key_id to the helm chart configmap