### PR TITLE
Update dead links to token specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ While performing simple user authentication is pretty straightforward, performin
 Docker Registry 2.0 introduced a new, token-based authentication and authorization protocol, but the server to generate them was not released.
 Thus, most guides found on the internet still describe a set up with a reverse proxy performing access control.
 
-This server fills the gap and implements the protocol described [here](https://github.com/docker/distribution/blob/main/docs/spec/auth/token.md).
+This server fills the gap and implements the protocol described [here](https://distribution.github.io/distribution/spec/auth/token/).
 
 Supported authentication methods:
  * Static list of users

--- a/auth_server/server/server.go
+++ b/auth_server/server/server.go
@@ -373,7 +373,9 @@ func (as *AuthServer) Authorize(ar *authRequest) ([]authzResult, error) {
 	return ares, nil
 }
 
-// https://github.com/docker/distribution/blob/master/docs/spec/auth/token.md#example
+// CreateToken implements the CNCF Token Authentication Specification
+//
+// See: https://distribution.github.io/distribution/spec/auth/token/
 func (as *AuthServer) CreateToken(ar *authRequest, ares []authzResult) (string, error) {
 	now := time.Now().Unix()
 	tc := &as.config.Token


### PR DESCRIPTION
This has been moved around in git a few times. Link to the doc site rather than an internal git branch.

See: https://github.com/distribution/distribution/pull/4101